### PR TITLE
iOS TestFlight platform 미설치 진단 강화 및 수동 실행 트리거 추가

### DIFF
--- a/.github/workflows/PROJECT-FLUTTER-IOS-TESTFLIGHT.yaml
+++ b/.github/workflows/PROJECT-FLUTTER-IOS-TESTFLIGHT.yaml
@@ -64,6 +64,8 @@ on:
     workflows: ["CHANGELOG 자동 업데이트"]
     types: [completed]
     branches: [main]
+  # 수동 실행 — deploy 배포 없이 iOS 빌드만 검증할 때 쓴다 (#46)
+  workflow_dispatch:
   workflow_dispatch:
 
 # ============================================
@@ -125,17 +127,24 @@ jobs:
           fi
           echo "선택된 Xcode: $(xcodebuild -version | head -1)"
 
-          echo "설치된 iOS 플랫폼 확인..."
-          if xcodebuild -showsdks 2>/dev/null | grep -q "iphoneos"; then
-            xcodebuild -showsdks 2>/dev/null | grep "iphoneos" || true
-            echo "✅ iOS SDK 사용 가능"
-          else
-            echo "⚠️  iOS SDK 없음 → 플랫폼 다운로드 시도 (수 분 소요)"
-            sudo xcodebuild -downloadPlatform iOS || {
-              echo "❌ iOS 플랫폼 설치 실패"
-              exit 1
-            }
-          fi
+          echo "── 설치된 Xcode ──"
+          ls -d /Applications/Xcode*.app 2>/dev/null || echo "  (없음)"
+
+          echo "── SDK 목록 ──"
+          xcodebuild -showsdks 2>/dev/null | grep -i "ios" || echo "  (iOS SDK 없음)"
+
+          # -showsdks 는 SDK 존재만 보여줄 뿐 platform 이 실제 설치됐는지는 알려주지 않는다.
+          # Xcode 16 부터 iOS platform 이 on-demand 컴포넌트로 분리되어,
+          # SDK 는 보이는데 storyboard 컴파일(ibtool) 단계에서
+          # "iOS X.Y Platform Not Installed" 로 실패하는 경우가 있다 (#46 실측).
+          echo "── 설치된 platform ──"
+          xcodebuild -showdestinations -scheme Runner 2>/dev/null | head -20 || true
+          ls /Library/Developer/CoreSimulator/Profiles/Runtimes/ 2>/dev/null || echo "  (런타임 디렉터리 없음)"
+
+          echo "── iOS platform 설치 시도 ──"
+          # 이미 설치돼 있으면 즉시 끝나고, 없으면 내려받는다.
+          # 실패해도 빌드를 진행한다 — 빌드 에러 로그가 더 정확한 진단을 준다.
+          sudo xcodebuild -downloadPlatform iOS 2>&1 | tail -20 ||             echo "⚠️  platform 다운로드 실패 또는 미지원 — 빌드를 그대로 진행한다"
 
       - name: Create .env file
         run: |
@@ -274,17 +283,24 @@ jobs:
           fi
           echo "선택된 Xcode: $(xcodebuild -version | head -1)"
 
-          echo "설치된 iOS 플랫폼 확인..."
-          if xcodebuild -showsdks 2>/dev/null | grep -q "iphoneos"; then
-            xcodebuild -showsdks 2>/dev/null | grep "iphoneos" || true
-            echo "✅ iOS SDK 사용 가능"
-          else
-            echo "⚠️  iOS SDK 없음 → 플랫폼 다운로드 시도 (수 분 소요)"
-            sudo xcodebuild -downloadPlatform iOS || {
-              echo "❌ iOS 플랫폼 설치 실패"
-              exit 1
-            }
-          fi
+          echo "── 설치된 Xcode ──"
+          ls -d /Applications/Xcode*.app 2>/dev/null || echo "  (없음)"
+
+          echo "── SDK 목록 ──"
+          xcodebuild -showsdks 2>/dev/null | grep -i "ios" || echo "  (iOS SDK 없음)"
+
+          # -showsdks 는 SDK 존재만 보여줄 뿐 platform 이 실제 설치됐는지는 알려주지 않는다.
+          # Xcode 16 부터 iOS platform 이 on-demand 컴포넌트로 분리되어,
+          # SDK 는 보이는데 storyboard 컴파일(ibtool) 단계에서
+          # "iOS X.Y Platform Not Installed" 로 실패하는 경우가 있다 (#46 실측).
+          echo "── 설치된 platform ──"
+          xcodebuild -showdestinations -scheme Runner 2>/dev/null | head -20 || true
+          ls /Library/Developer/CoreSimulator/Profiles/Runtimes/ 2>/dev/null || echo "  (런타임 디렉터리 없음)"
+
+          echo "── iOS platform 설치 시도 ──"
+          # 이미 설치돼 있으면 즉시 끝나고, 없으면 내려받는다.
+          # 실패해도 빌드를 진행한다 — 빌드 에러 로그가 더 정확한 진단을 준다.
+          sudo xcodebuild -downloadPlatform iOS 2>&1 | tail -20 ||             echo "⚠️  platform 다운로드 실패 또는 미지원 — 빌드를 그대로 진행한다"
 
       - name: Download project files
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## 개요

[#46](https://github.com/Cassiiopeia/EarLocAlert/issues/46) 후속. Android Synology 는 복구됐으나 **iOS TestFlight 는 여전히 실패**합니다. 정확한 원인을 좁히기 위한 진단 강화와, 배포 없이 검증할 수 있는 수동 실행 트리거를 추가합니다.

## 지금까지 밝혀진 것

첫 수정에서 Xcode 선택을 방어적으로 바꿨고, 그 결과 다음이 확인됐습니다:

```
✅ Xcode 16.3 선택
선택된 Xcode: Xcode 16.3
설치된 iOS 플랫폼 확인...
	iOS 18.4                      	-sdk iphoneos18.4
✅ iOS SDK 사용 가능
```

**SDK 는 정상 인식됩니다.** 그런데 빌드는 여전히 실패하고, 에러가 가리키는 대상이 결정적입니다:

```
Error (Xcode): iOS 18.4 Platform Not Installed.
/Users/runner/work/EarLocAlert/EarLocAlert/ios/Runner/Base.lproj/Main.storyboard
```

`Main.storyboard` — 즉 **SDK 부재가 아니라 스토리보드 컴파일(ibtool) 단계**에서 platform 리소스를 찾지 못하는 것입니다. Xcode 16 부터 iOS platform 이 on-demand 컴포넌트로 분리되어, `xcodebuild -showsdks` 는 SDK 를 보여주지만 platform 자체는 설치되지 않은 상태가 존재합니다.

## 변경 내용

### 1. `workflow_dispatch` 추가

지금까지 iOS 빌드를 검증하려면 **매번 실제 deploy 배포를 해야 했습니다.** 수동 실행 트리거를 추가해 배포 없이 iOS 빌드만 돌려볼 수 있게 합니다.

### 2. platform 진단 강화 + 설치 시도

- 설치된 Xcode 목록을 항상 출력 (기존엔 폴백 분기에서만 출력돼 로그가 안 남았습니다)
- SDK 목록 · 시뮬레이터 런타임 디렉터리 출력
- `xcodebuild -downloadPlatform iOS` 를 **조건 없이** 실행 — 이미 설치돼 있으면 즉시 끝나고, 없으면 내려받습니다
- 다운로드가 실패해도 빌드를 그대로 진행합니다. 어차피 실패할 상황이면 **빌드 에러 로그가 더 정확한 진단**을 주기 때문입니다

## 검증 방법

머지 후 `workflow_dispatch` 로 iOS 빌드만 수동 실행해 확인합니다. 배포 사이클을 돌리지 않아도 됩니다.

## 남은 가능성

`-downloadPlatform` 으로 해결되지 않으면 다음 순서로 접근합니다:

1. 러너에 설치된 다른 Xcode 버전으로 전환 (진단 로그로 목록 확보됨)
2. `Main.storyboard` 제거 — Flutter 는 `FlutterViewController` 를 코드로 띄우므로 이 스토리보드를 실제로 쓰지 않습니다. 다만 프로젝트 설정 변경이 따르므로 마지막 수단입니다
