### PR TITLE
Drift 기반 로컬 저장소 계층 및 리포지토리 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ android/app/keystore/*.keystore
 
 # Play Store 배포 시크릿 (service account, keystore 등)
 playstore-secrets/
+
+# 코드 생성 산출물 — CI 의 build_runner 가 만든다 (내부망 개발환경에서 로컬 생성 불가)
+*.g.dart
+*.freezed.dart

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,28 +1,16 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
+# Flutter 권장 lint + 이 프로젝트의 경계 규칙 (docs/02-ARCHITECTURE.md)
 include: package:flutter_lints/flutter.yaml
 
-linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at https://dart.dev/lints.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
-  rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+analyzer:
+  plugins:
+    # Riverpod 오용·Provider 누락 검사 (docs/02-ARCHITECTURE.md)
+    - custom_lint
+  exclude:
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
 
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+linter:
+  rules:
+    # 릴리스 로그에 위치 좌표가 남지 않도록 print 를 금지한다
+    # (docs/04-CONVENTIONS.md — 좌표는 개인정보다)
+    avoid_print: true

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'tables.dart';
+
+part 'app_database.g.dart';
+
+/// 앱 로컬 데이터베이스 (docs/03-DOMAIN.md 저장소 경계)
+///
+/// 백그라운드 진입점에서도 열린다 — 포그라운드 서비스·지오펜스 콜백은
+/// UI 없이 실행되므로 이 클래스가 `BuildContext` 에 의존해서는 안 된다
+/// (docs/02-ARCHITECTURE.md 규칙 5).
+@DriftDatabase(tables: [AlertPlaces, GeofenceEvents, GeofenceStates])
+class AppDatabase extends _$AppDatabase {
+  AppDatabase() : super(_openConnection());
+
+  /// 테스트용 — 인메모리 DB 를 주입한다
+  AppDatabase.forTesting(super.executor);
+
+  @override
+  int get schemaVersion => 1;
+}
+
+QueryExecutor _openConnection() {
+  return LazyDatabase(() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File(p.join(dir.path, 'ear_loc_alert.sqlite'));
+    return NativeDatabase.createInBackground(file);
+  });
+}

--- a/lib/core/database/tables.dart
+++ b/lib/core/database/tables.dart
@@ -1,0 +1,79 @@
+import 'package:drift/drift.dart';
+
+/// 알림을 걸어둔 장소 (docs/03-DOMAIN.md)
+@DataClassName('AlertPlaceRow')
+class AlertPlaces extends Table {
+  /// UUIDv7 — 앱에서 생성한다
+  TextColumn get id => text()();
+
+  TextColumn get name => text().withLength(min: 1, max: 100)();
+  RealColumn get latitude => real()();
+  RealColumn get longitude => real()();
+
+  /// 50 ~ 2000 (docs/01-REQUIREMENTS.md F1.4)
+  IntColumn get radiusMeters => integer()();
+
+  /// AlertDirection 인덱스
+  IntColumn get direction => integer()();
+
+  /// 삭제하지 않고 잠시 끄는 수단 (F1.7)
+  BoolColumn get enabled => boolean().withDefault(const Constant(true))();
+
+  BoolColumn get soundEnabled => boolean().withDefault(const Constant(true))();
+
+  /// UTC (docs/04-CONVENTIONS.md)
+  DateTimeColumn get createdAt => dateTime()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+/// 진입/이탈 이력 (docs/03-DOMAIN.md)
+///
+/// F7(이력 조회)은 Phase 2 지만 이 기록은 MVP 부터 남긴다 —
+/// "안 울렸다"는 문제를 조사할 유일한 수단이다.
+@DataClassName('GeofenceEventRow')
+class GeofenceEvents extends Table {
+  TextColumn get id => text()();
+
+  /// 값 참조 — 외래키를 걸지 않는다.
+  /// 장소를 지워도 "언제 울렸는지" 기록은 남아야 조사가 가능하다.
+  TextColumn get placeId => text()();
+
+  /// GeofenceEventType 인덱스
+  IntColumn get type => integer()();
+
+  /// UTC
+  DateTimeColumn get occurredAt => dateTime()();
+
+  RealColumn get latitude => real()();
+  RealColumn get longitude => real()();
+
+  /// 판정 시점의 GPS 정확도 — 오작동 조사의 핵심 단서
+  RealColumn get accuracyMeters => real()();
+
+  /// 실제로 알림을 띄웠는지.
+  /// 판정이 안 된 것인지, 판정은 됐는데 알림이 실패한 것인지를 가른다.
+  BoolColumn get notified => boolean()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+/// 장소별 지오펜스 현재 상태 (docs/03-DOMAIN.md)
+///
+/// **메모리에 두지 않는 것이 중요하다.** 재부팅하면 전부 `unknown` 이 되고,
+/// 그러면 "밖에 있었다는 사실"이 사라져 첫 진입 알림을 놓친다.
+@DataClassName('GeofenceStateRow')
+class GeofenceStates extends Table {
+  TextColumn get placeId => text()();
+
+  /// GeofenceState 인덱스
+  IntColumn get state => integer()();
+
+  /// 마지막으로 상태가 갱신된 시각 (UTC)
+  DateTimeColumn get updatedAt => dateTime()();
+
+  @override
+  Set<Column> get primaryKey => {placeId};
+}

--- a/lib/core/di/providers.dart
+++ b/lib/core/di/providers.dart
@@ -1,0 +1,47 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../features/geofence/data/drift_geofence_event_repository.dart';
+import '../../features/geofence/data/drift_geofence_state_repository.dart';
+import '../../features/geofence/domain/geofence_event_repository.dart';
+import '../../features/geofence/domain/geofence_evaluator.dart';
+import '../../features/geofence/domain/geofence_state_repository.dart';
+import '../../features/places/data/drift_place_repository.dart';
+import '../../features/places/domain/place_repository.dart';
+import '../database/app_database.dart';
+
+part 'providers.g.dart';
+
+/// 의존성 등록 (docs/02-ARCHITECTURE.md)
+///
+/// DI 는 Riverpod 으로 통일한다 — `get_it` 을 병행하지 않는다.
+/// Provider 는 손으로 선언하지 않고 전부 코드 생성이다
+/// (docs/04-CONVENTIONS.md).
+///
+/// 화면은 여기서 **인터페이스 타입**을 받는다. Drift 구현체를 직접
+/// 참조하지 않으므로 저장소 교체가 화면 코드를 건드리지 않는다.
+
+@Riverpod(keepAlive: true)
+AppDatabase appDatabase(Ref ref) {
+  final db = AppDatabase();
+  ref.onDispose(db.close);
+  return db;
+}
+
+@Riverpod(keepAlive: true)
+PlaceRepository placeRepository(Ref ref) {
+  return DriftPlaceRepository(ref.watch(appDatabaseProvider));
+}
+
+@Riverpod(keepAlive: true)
+GeofenceEventRepository geofenceEventRepository(Ref ref) {
+  return DriftGeofenceEventRepository(ref.watch(appDatabaseProvider));
+}
+
+@Riverpod(keepAlive: true)
+GeofenceStateRepository geofenceStateRepository(Ref ref) {
+  return DriftGeofenceStateRepository(ref.watch(appDatabaseProvider));
+}
+
+/// 판정 로직은 상태가 없는 순수 객체다
+@Riverpod(keepAlive: true)
+GeofenceEvaluator geofenceEvaluator(Ref ref) => const GeofenceEvaluator();

--- a/lib/core/di/providers.dart
+++ b/lib/core/di/providers.dart
@@ -1,3 +1,5 @@
+// Ref 는 riverpod_annotation 이 아니라 flutter_riverpod 이 제공한다
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../features/geofence/data/drift_geofence_event_repository.dart';

--- a/lib/core/domain/id_generator.dart
+++ b/lib/core/domain/id_generator.dart
@@ -1,0 +1,14 @@
+import 'package:uuid/uuid.dart';
+
+/// 식별자 생성 (docs/03-DOMAIN.md)
+///
+/// **저장 전에 앱이 만든다.** DB 자동 증가를 쓰지 않는다 —
+/// 플랫폼 지오펜스에 등록할 때 식별자가 먼저 필요하고,
+/// 나중에 기기 간 동기화를 붙일 여지를 남긴다.
+///
+/// UUIDv7 은 상위 비트가 타임스탬프라 시간순 정렬된다.
+abstract final class IdGenerator {
+  static const _uuid = Uuid();
+
+  static String generate() => _uuid.v7();
+}

--- a/lib/core/domain/retention_policy.dart
+++ b/lib/core/domain/retention_policy.dart
@@ -1,0 +1,14 @@
+/// 이력 보관 정책 (docs/03-DOMAIN.md)
+///
+/// `GeofenceEvent` 는 무한히 쌓인다. 기기 저장소를 계속 잠식하면 안 되고,
+/// 90일 전 진입 기록이 필요한 사용자는 없다.
+abstract final class RetentionPolicy {
+  static const Duration eventRetention = Duration(days: 90);
+
+  /// [now] 기준으로 이보다 오래된 이력은 삭제 대상이다.
+  ///
+  /// 순수 함수라 시각을 주입해 테스트할 수 있다 — `DateTime.now()` 를
+  /// 내부에서 부르면 경계 조건 검증이 불가능해진다.
+  static DateTime cutoffFrom(DateTime now) =>
+      now.toUtc().subtract(eventRetention);
+}

--- a/lib/features/geofence/data/drift_geofence_event_repository.dart
+++ b/lib/features/geofence/data/drift_geofence_event_repository.dart
@@ -1,0 +1,72 @@
+import 'package:drift/drift.dart';
+
+import '../../../core/database/app_database.dart';
+import '../domain/geofence_event.dart';
+import '../domain/geofence_event_repository.dart';
+
+/// Drift 기반 [GeofenceEventRepository] 구현
+class DriftGeofenceEventRepository implements GeofenceEventRepository {
+  DriftGeofenceEventRepository(this._db);
+
+  final AppDatabase _db;
+
+  @override
+  Future<void> record(GeofenceEvent event) async {
+    await _db
+        .into(_db.geofenceEvents)
+        .insertOnConflictUpdate(
+          GeofenceEventsCompanion(
+            id: Value(event.id),
+            placeId: Value(event.placeId),
+            type: Value(event.type.index),
+            occurredAt: Value(event.occurredAt.toUtc()),
+            latitude: Value(event.latitude),
+            longitude: Value(event.longitude),
+            accuracyMeters: Value(event.accuracyMeters),
+            notified: Value(event.notified),
+          ),
+        );
+  }
+
+  @override
+  Future<List<GeofenceEvent>> findRecent({int limit = 100}) async {
+    final query = _db.select(_db.geofenceEvents)
+      ..orderBy([(t) => OrderingTerm.desc(t.occurredAt)])
+      ..limit(limit);
+    final rows = await query.get();
+    return rows.map(_toDomain).toList();
+  }
+
+  @override
+  Future<List<GeofenceEvent>> findByPlace(
+    String placeId, {
+    int limit = 100,
+  }) async {
+    final query = _db.select(_db.geofenceEvents)
+      ..where((t) => t.placeId.equals(placeId))
+      ..orderBy([(t) => OrderingTerm.desc(t.occurredAt)])
+      ..limit(limit);
+    final rows = await query.get();
+    return rows.map(_toDomain).toList();
+  }
+
+  @override
+  Future<int> deleteOlderThan(DateTime cutoffUtc) async {
+    final stmt = _db.delete(_db.geofenceEvents)
+      ..where((t) => t.occurredAt.isSmallerThanValue(cutoffUtc.toUtc()));
+    return stmt.go();
+  }
+
+  GeofenceEvent _toDomain(GeofenceEventRow row) {
+    return GeofenceEvent(
+      id: row.id,
+      placeId: row.placeId,
+      type: GeofenceEventType.values[row.type],
+      occurredAt: row.occurredAt.toUtc(),
+      latitude: row.latitude,
+      longitude: row.longitude,
+      accuracyMeters: row.accuracyMeters,
+      notified: row.notified,
+    );
+  }
+}

--- a/lib/features/geofence/data/drift_geofence_state_repository.dart
+++ b/lib/features/geofence/data/drift_geofence_state_repository.dart
@@ -1,0 +1,53 @@
+import 'package:drift/drift.dart';
+
+import '../../../core/database/app_database.dart';
+import '../domain/geofence_state.dart';
+import '../domain/geofence_state_repository.dart';
+
+/// Drift 기반 [GeofenceStateRepository] 구현
+///
+/// 저장된 상태가 없으면 [GeofenceState.unknown] 을 돌려준다 —
+/// 등록 직후의 장소가 여기 해당하며, 첫 판정에서는 알림이 발생하지 않는다
+/// (docs/03-DOMAIN.md).
+class DriftGeofenceStateRepository implements GeofenceStateRepository {
+  DriftGeofenceStateRepository(this._db);
+
+  final AppDatabase _db;
+
+  @override
+  Future<GeofenceState> stateOf(String placeId) async {
+    final query = _db.select(_db.geofenceStates)
+      ..where((t) => t.placeId.equals(placeId));
+    final row = await query.getSingleOrNull();
+    if (row == null) return GeofenceState.unknown;
+    return GeofenceState.values[row.state];
+  }
+
+  @override
+  Future<Map<String, GeofenceState>> allStates() async {
+    final rows = await _db.select(_db.geofenceStates).get();
+    return {
+      for (final row in rows) row.placeId: GeofenceState.values[row.state],
+    };
+  }
+
+  @override
+  Future<void> updateState(String placeId, GeofenceState state) async {
+    await _db
+        .into(_db.geofenceStates)
+        .insertOnConflictUpdate(
+          GeofenceStatesCompanion(
+            placeId: Value(placeId),
+            state: Value(state.index),
+            updatedAt: Value(DateTime.now().toUtc()),
+          ),
+        );
+  }
+
+  @override
+  Future<void> remove(String placeId) async {
+    await (_db.delete(
+      _db.geofenceStates,
+    )..where((t) => t.placeId.equals(placeId))).go();
+  }
+}

--- a/lib/features/geofence/domain/geofence_event_repository.dart
+++ b/lib/features/geofence/domain/geofence_event_repository.dart
@@ -1,0 +1,23 @@
+import 'geofence_event.dart';
+
+/// 진입/이탈 이력 저장소 (docs/03-DOMAIN.md)
+///
+/// F7(이력 화면)은 Phase 2 지만 기록은 MVP 부터 남긴다.
+/// 이 저장소가 없으면 "안 울렸다"는 문제를 조사할 방법이 전혀 없다.
+abstract interface class GeofenceEventRepository {
+  Future<void> record(GeofenceEvent event);
+
+  /// 최근 이력 (발생 시각 내림차순)
+  Future<List<GeofenceEvent>> findRecent({int limit = 100});
+
+  /// 특정 장소의 이력
+  Future<List<GeofenceEvent>> findByPlace(String placeId, {int limit = 100});
+
+  /// 보관 기간이 지난 기록 삭제 (docs/03-DOMAIN.md — 90일)
+  ///
+  /// 기기 저장소를 계속 잠식하면 안 되고, 90일 전 진입 기록이
+  /// 필요한 사용자는 없다. 앱 시작 시 1회 호출한다.
+  ///
+  /// 삭제된 행 수를 반환한다.
+  Future<int> deleteOlderThan(DateTime cutoffUtc);
+}

--- a/lib/features/geofence/domain/geofence_state_repository.dart
+++ b/lib/features/geofence/domain/geofence_state_repository.dart
@@ -1,0 +1,21 @@
+import 'geofence_state.dart';
+
+/// 장소별 지오펜스 현재 상태 저장소 (docs/03-DOMAIN.md)
+///
+/// **이 저장소가 영속적이어야 하는 이유**가 이 앱에서 가장 미묘한 부분이다.
+///
+/// 알림은 `outside → inside` 전이에서만 발생한다. 상태를 메모리에만 두면
+/// 재부팅 후 전부 `unknown` 이 되고, `unknown → inside` 는 알림을 만들지
+/// 않으므로 **첫 진입 알림을 통째로 놓친다.**
+abstract interface class GeofenceStateRepository {
+  /// 저장된 상태. 없으면 `unknown`
+  Future<GeofenceState> stateOf(String placeId);
+
+  /// 전체 상태를 한 번에 (백그라운드 판정 루프용)
+  Future<Map<String, GeofenceState>> allStates();
+
+  Future<void> updateState(String placeId, GeofenceState state);
+
+  /// 장소가 삭제되면 상태도 함께 지운다
+  Future<void> remove(String placeId);
+}

--- a/lib/features/places/data/drift_place_repository.dart
+++ b/lib/features/places/data/drift_place_repository.dart
@@ -1,0 +1,102 @@
+import 'package:drift/drift.dart';
+
+import '../../../core/database/app_database.dart';
+import '../../../core/domain/alert_direction.dart';
+import '../domain/alert_place.dart';
+import '../domain/place_repository.dart';
+
+/// Drift 기반 [PlaceRepository] 구현 (docs/02-ARCHITECTURE.md)
+///
+/// Drift 예외를 그대로 위로 올리지 않는다 — 화면이 `DriftRemoteException` 을
+/// 아는 순간 저장소 교체가 불가능해진다 (docs/04-CONVENTIONS.md).
+class DriftPlaceRepository implements PlaceRepository {
+  DriftPlaceRepository(this._db);
+
+  final AppDatabase _db;
+
+  @override
+  Future<List<AlertPlace>> findAll() async {
+    final query = _db.select(_db.alertPlaces)
+      ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]);
+    final rows = await query.get();
+    return rows.map(_toDomain).toList();
+  }
+
+  @override
+  Future<List<AlertPlace>> findEnabled() async {
+    final query = _db.select(_db.alertPlaces)
+      ..where((t) => t.enabled.equals(true))
+      ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]);
+    final rows = await query.get();
+    return rows.map(_toDomain).toList();
+  }
+
+  @override
+  Future<AlertPlace?> findById(String id) async {
+    final query = _db.select(_db.alertPlaces)..where((t) => t.id.equals(id));
+    final row = await query.getSingleOrNull();
+    return row == null ? null : _toDomain(row);
+  }
+
+  @override
+  Future<void> save(AlertPlace place) async {
+    await _db.into(_db.alertPlaces).insertOnConflictUpdate(_toRow(place));
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    await (_db.delete(_db.alertPlaces)..where((t) => t.id.equals(id))).go();
+  }
+
+  @override
+  Future<void> setEnabled(String id, {required bool enabled}) async {
+    await (_db.update(_db.alertPlaces)..where((t) => t.id.equals(id))).write(
+      AlertPlacesCompanion(enabled: Value(enabled)),
+    );
+  }
+
+  @override
+  Future<int> count() async {
+    final countExp = _db.alertPlaces.id.count();
+    final query = _db.selectOnly(_db.alertPlaces)..addColumns([countExp]);
+    final row = await query.getSingle();
+    return row.read(countExp) ?? 0;
+  }
+
+  @override
+  Stream<List<AlertPlace>> watchAll() {
+    final query = _db.select(_db.alertPlaces)
+      ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]);
+    return query.watch().map((rows) => rows.map(_toDomain).toList());
+  }
+
+  AlertPlace _toDomain(AlertPlaceRow row) {
+    return AlertPlace(
+      id: row.id,
+      name: row.name,
+      latitude: row.latitude,
+      longitude: row.longitude,
+      radiusMeters: row.radiusMeters,
+      direction: AlertDirection.values[row.direction],
+      enabled: row.enabled,
+      soundEnabled: row.soundEnabled,
+      // Drift 는 DateTime 을 로컬로 되돌려주므로 UTC 로 되돌린다
+      // (docs/04-CONVENTIONS.md — 저장은 UTC, 표시 직전에만 로컬)
+      createdAt: row.createdAt.toUtc(),
+    );
+  }
+
+  AlertPlacesCompanion _toRow(AlertPlace place) {
+    return AlertPlacesCompanion(
+      id: Value(place.id),
+      name: Value(place.name),
+      latitude: Value(place.latitude),
+      longitude: Value(place.longitude),
+      radiusMeters: Value(place.radiusMeters),
+      direction: Value(place.direction.index),
+      enabled: Value(place.enabled),
+      soundEnabled: Value(place.soundEnabled),
+      createdAt: Value(place.createdAt.toUtc()),
+    );
+  }
+}

--- a/lib/features/places/domain/place_repository.dart
+++ b/lib/features/places/domain/place_repository.dart
@@ -1,0 +1,29 @@
+import 'alert_place.dart';
+
+/// 장소 저장소 (docs/02-ARCHITECTURE.md 규칙 3)
+///
+/// 화면은 이 인터페이스만 본다. 구현이 Drift 인지 아닌지 알지 못하며,
+/// 테스트에서는 가짜 구현을 넣는다.
+abstract interface class PlaceRepository {
+  /// 등록된 모든 장소 (생성 시각 오름차순)
+  Future<List<AlertPlace>> findAll();
+
+  /// 감시 대상만 — `enabled == true`
+  Future<List<AlertPlace>> findEnabled();
+
+  Future<AlertPlace?> findById(String id);
+
+  /// 등록 또는 수정. `id` 는 호출자가 미리 생성해 넘긴다
+  Future<void> save(AlertPlace place);
+
+  Future<void> delete(String id);
+
+  /// 활성/비활성 토글 (F1.7)
+  Future<void> setEnabled(String id, {required bool enabled});
+
+  /// 등록 개수 — iOS 20개 제한 확인에 쓴다 (docs/05-PLATFORM.md)
+  Future<int> count();
+
+  /// 목록 변경 스트림. 화면이 구독한다
+  Stream<List<AlertPlace>> watchAll();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,25 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.8
   freezed_annotation: ^3.0.0
+  # 상태 관리 · DI — Riverpod 으로 통일한다. provider·get_it 병행 금지 (docs/02-ARCHITECTURE.md)
+  flutter_riverpod: ^2.6.1
+  riverpod_annotation: ^2.6.1
+  # 로컬 저장소 — Drift(SQLite). Hive·Isar 를 쓰지 않는다 (docs/10-DECISIONS.md 003)
+  drift: ^2.20.0
+  sqlite3_flutter_libs: ^0.5.24
+  path_provider: ^2.1.4
+  path: ^1.9.0
+  # 식별자 — 저장 전에 앱이 생성한다 (docs/03-DOMAIN.md)
+  uuid: ^4.5.1
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
   build_runner: ^2.4.6
   freezed: ^3.0.0
+  drift_dev: ^2.20.0
+  riverpod_generator: ^2.6.1
+  custom_lint: ^0.7.0
+  riverpod_lint: ^2.6.1
 flutter:
   uses-material-design: true

--- a/test/core/retention_policy_test.dart
+++ b/test/core/retention_policy_test.dart
@@ -1,0 +1,30 @@
+import 'package:ear_loc_alert/core/domain/retention_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 8, 3, 12);
+
+  group('이력 보관 기간 (docs/03-DOMAIN.md)', () {
+    test('컷오프는 90일 전이다', () {
+      expect(RetentionPolicy.cutoffFrom(now), DateTime.utc(2026, 5, 5, 12));
+    });
+
+    test('로컬 시각을 넣어도 UTC 기준으로 계산한다', () {
+      final local = DateTime.utc(2026, 8, 3, 12).toLocal();
+      expect(
+        RetentionPolicy.cutoffFrom(local),
+        RetentionPolicy.cutoffFrom(now),
+      );
+    });
+
+    test('89일 된 기록은 보존 대상이다', () {
+      final event = now.subtract(const Duration(days: 89));
+      expect(event.isAfter(RetentionPolicy.cutoffFrom(now)), isTrue);
+    });
+
+    test('91일 된 기록은 삭제 대상이다', () {
+      final event = now.subtract(const Duration(days: 91));
+      expect(event.isBefore(RetentionPolicy.cutoffFrom(now)), isTrue);
+    });
+  });
+}

--- a/test/features/geofence/geofence_state_repository_contract_test.dart
+++ b/test/features/geofence/geofence_state_repository_contract_test.dart
@@ -1,0 +1,86 @@
+import 'package:ear_loc_alert/features/geofence/domain/geofence_state.dart';
+import 'package:ear_loc_alert/features/geofence/domain/geofence_state_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// [GeofenceStateRepository] 계약 테스트.
+///
+/// 이 저장소의 계약 중 하나가 이 앱에서 가장 미묘하다 —
+/// **저장된 적 없는 장소는 `unknown` 을 돌려줘야 한다.**
+/// 이 규칙이 깨지면 앱 시작 직후 이미 반경 안에 있는 사용자에게
+/// "방금 진입했다"는 알림이 잘못 발생한다.
+class InMemoryGeofenceStateRepository implements GeofenceStateRepository {
+  final Map<String, GeofenceState> _store = {};
+
+  @override
+  Future<GeofenceState> stateOf(String placeId) async =>
+      _store[placeId] ?? GeofenceState.unknown;
+
+  @override
+  Future<Map<String, GeofenceState>> allStates() async => Map.of(_store);
+
+  @override
+  Future<void> updateState(String placeId, GeofenceState state) async {
+    _store[placeId] = state;
+  }
+
+  @override
+  Future<void> remove(String placeId) async {
+    _store.remove(placeId);
+  }
+}
+
+void main() {
+  late InMemoryGeofenceStateRepository repo;
+
+  setUp(() => repo = InMemoryGeofenceStateRepository());
+
+  group('GeofenceStateRepository 계약', () {
+    test('저장된 적 없는 장소는 unknown 이다', () async {
+      expect(await repo.stateOf('처음'), GeofenceState.unknown);
+    });
+
+    test('저장한 상태를 그대로 돌려준다', () async {
+      await repo.updateState('a', GeofenceState.outside);
+      expect(await repo.stateOf('a'), GeofenceState.outside);
+    });
+
+    test('상태는 덮어쓰기다', () async {
+      await repo.updateState('a', GeofenceState.outside);
+      await repo.updateState('a', GeofenceState.inside);
+      expect(await repo.stateOf('a'), GeofenceState.inside);
+    });
+
+    test('allStates 는 저장된 장소만 담는다', () async {
+      await repo.updateState('a', GeofenceState.inside);
+      await repo.updateState('b', GeofenceState.outside);
+
+      final all = await repo.allStates();
+      expect(all, {'a': GeofenceState.inside, 'b': GeofenceState.outside});
+    });
+
+    test('remove 후에는 다시 unknown 이 된다', () async {
+      await repo.updateState('a', GeofenceState.inside);
+      await repo.remove('a');
+      expect(await repo.stateOf('a'), GeofenceState.unknown);
+    });
+
+    test('없는 장소를 remove 해도 죽지 않는다', () async {
+      await repo.remove('없음');
+      expect(await repo.allStates(), isEmpty);
+    });
+
+    test('재부팅 시나리오 — 저장된 outside 가 살아있어야 진입 알림이 가능하다', () async {
+      // 재부팅 전: 집 밖에 있었다
+      await repo.updateState('집', GeofenceState.outside);
+
+      // 재부팅 후 새 인스턴스가 같은 저장소를 읽는다고 가정
+      final restored = await repo.stateOf('집');
+
+      expect(
+        restored,
+        GeofenceState.outside,
+        reason: 'unknown 으로 돌아가면 outside → inside 전이가 사라져 첫 진입 알림을 놓친다',
+      );
+    });
+  });
+}

--- a/test/features/places/place_repository_contract_test.dart
+++ b/test/features/places/place_repository_contract_test.dart
@@ -1,0 +1,170 @@
+import 'dart:async';
+
+import 'package:ear_loc_alert/core/domain/alert_direction.dart';
+import 'package:ear_loc_alert/features/places/domain/alert_place.dart';
+import 'package:ear_loc_alert/features/places/domain/place_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// [PlaceRepository] 계약 테스트.
+///
+/// Drift 구현 자체는 테스트하지 않는다 — Drift 를 믿는다
+/// (docs/04-CONVENTIONS.md). 여기서 검증하는 것은 **인터페이스가 약속한 동작**
+/// 이며, 이 테스트를 통과하는 구현이면 화면이 기대한 대로 동작한다.
+class InMemoryPlaceRepository implements PlaceRepository {
+  final Map<String, AlertPlace> _store = {};
+  final _controller = StreamController<List<AlertPlace>>.broadcast();
+
+  List<AlertPlace> get _sorted =>
+      _store.values.toList()
+        ..sort((a, b) => a.createdAt.compareTo(b.createdAt));
+
+  void _emit() => _controller.add(_sorted);
+
+  @override
+  Future<List<AlertPlace>> findAll() async => _sorted;
+
+  @override
+  Future<List<AlertPlace>> findEnabled() async =>
+      _sorted.where((p) => p.enabled).toList();
+
+  @override
+  Future<AlertPlace?> findById(String id) async => _store[id];
+
+  @override
+  Future<void> save(AlertPlace place) async {
+    _store[place.id] = place;
+    _emit();
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    _store.remove(id);
+    _emit();
+  }
+
+  @override
+  Future<void> setEnabled(String id, {required bool enabled}) async {
+    final place = _store[id];
+    if (place == null) return;
+    _store[id] = place.copyWith(enabled: enabled);
+    _emit();
+  }
+
+  @override
+  Future<int> count() async => _store.length;
+
+  @override
+  Stream<List<AlertPlace>> watchAll() => _controller.stream;
+
+  void dispose() => _controller.close();
+}
+
+AlertPlace makePlace({
+  required String id,
+  String name = '장소',
+  bool enabled = true,
+  int createdAtOffsetMinutes = 0,
+}) {
+  return AlertPlace(
+    id: id,
+    name: name,
+    latitude: 37.5663,
+    longitude: 126.9779,
+    radiusMeters: 100,
+    direction: AlertDirection.both,
+    enabled: enabled,
+    createdAt: DateTime.utc(
+      2026,
+      8,
+      3,
+      12,
+    ).add(Duration(minutes: createdAtOffsetMinutes)),
+  );
+}
+
+void main() {
+  late InMemoryPlaceRepository repo;
+
+  setUp(() => repo = InMemoryPlaceRepository());
+  tearDown(() => repo.dispose());
+
+  group('PlaceRepository 계약', () {
+    test('저장한 장소를 id 로 조회할 수 있다', () async {
+      await repo.save(makePlace(id: 'a', name: '학원'));
+
+      final found = await repo.findById('a');
+      expect(found?.name, '학원');
+    });
+
+    test('없는 id 조회는 null 이다 — 예외를 던지지 않는다', () async {
+      expect(await repo.findById('없음'), isNull);
+    });
+
+    test('같은 id 로 저장하면 덮어쓴다', () async {
+      await repo.save(makePlace(id: 'a', name: '이전'));
+      await repo.save(makePlace(id: 'a', name: '이후'));
+
+      expect(await repo.count(), 1);
+      expect((await repo.findById('a'))?.name, '이후');
+    });
+
+    test('findAll 은 생성 시각 오름차순이다', () async {
+      await repo.save(makePlace(id: 'b', createdAtOffsetMinutes: 10));
+      await repo.save(makePlace(id: 'a', createdAtOffsetMinutes: 0));
+
+      final all = await repo.findAll();
+      expect(all.map((p) => p.id), ['a', 'b']);
+    });
+
+    test('findEnabled 는 비활성 장소를 제외한다 (F1.7)', () async {
+      await repo.save(makePlace(id: 'on'));
+      await repo.save(makePlace(id: 'off', enabled: false));
+
+      final enabled = await repo.findEnabled();
+      expect(enabled.map((p) => p.id), ['on']);
+    });
+
+    test('setEnabled 는 장소를 지우지 않고 상태만 바꾼다', () async {
+      await repo.save(makePlace(id: 'a'));
+
+      await repo.setEnabled('a', enabled: false);
+
+      expect(await repo.count(), 1, reason: '삭제되면 안 된다');
+      expect((await repo.findById('a'))?.enabled, isFalse);
+      expect(await repo.findEnabled(), isEmpty);
+    });
+
+    test('없는 id 에 setEnabled 해도 죽지 않는다', () async {
+      await repo.setEnabled('없음', enabled: false);
+      expect(await repo.count(), 0);
+    });
+
+    test('delete 후에는 조회되지 않는다', () async {
+      await repo.save(makePlace(id: 'a'));
+      await repo.delete('a');
+
+      expect(await repo.findById('a'), isNull);
+      expect(await repo.count(), 0);
+    });
+
+    test('count 는 iOS 20개 제한 확인에 쓸 수 있다', () async {
+      for (var i = 0; i < 20; i++) {
+        await repo.save(makePlace(id: 'p$i', createdAtOffsetMinutes: i));
+      }
+      expect(await repo.count(), 20);
+    });
+
+    test('watchAll 은 변경 시마다 목록을 흘려보낸다', () async {
+      final emitted = <int>[];
+      final sub = repo.watchAll().listen((list) => emitted.add(list.length));
+
+      await repo.save(makePlace(id: 'a'));
+      await repo.save(makePlace(id: 'b', createdAtOffsetMinutes: 1));
+      await repo.delete('a');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, [1, 2, 1]);
+      await sub.cancel();
+    });
+  });
+}


### PR DESCRIPTION
## 개요

#43 에서 만든 도메인 모델을 **영속 저장**할 계층을 구현했습니다.

- 관련 이슈: https://github.com/Cassiiopeia/EarLocAlert/issues/53

## 왜 지금 필요한가

저장소 부재는 단순 미구현이 아니라 **기능을 성립 불가능하게** 만듭니다. 특히 지오펜스 상태가 그렇습니다:

알림은 `outside → inside` 전이에서만 발생하는데, 상태를 메모리에만 두면 **재부팅 시 전부 `unknown` 이 되어 "밖에 있었다는 사실"이 사라지고 첫 진입 알림을 통째로 놓칩니다.** 그래서 `geofence_states` 를 DB 에 둡니다.

## 변경 내용

### Drift 스키마 v1

| 테이블 | 용도 |
|---|---|
| `alert_places` | 등록한 장소 |
| `geofence_events` | 진입/이탈 이력 (F7 은 Phase 2 지만 기록은 MVP 부터) |
| `geofence_states` | **장소별 현재 상태 — 재부팅 후에도 살아있어야 한다** |

시각 컬럼은 전부 UTC 저장, 조회 시 `toUtc()` 로 정규화합니다.

### 리포지토리 — 인터페이스와 구현 분리

`domain/` 에 인터페이스, `data/` 에 Drift 구현을 두어 **화면이 Drift 를 모르게** 합니다 (docs/02-ARCHITECTURE.md 규칙 3). 저장소 교체가 화면 코드를 건드리지 않고, 테스트에서 가짜 구현을 넣을 수 있습니다.

`geofence_events` 에는 **외래키를 걸지 않았습니다.** 장소를 지워도 "언제 울렸는지" 기록은 남아야 조사가 가능하기 때문입니다.

### Riverpod DI

`@riverpod` 코드 생성 방식으로만 등록합니다. `get_it` 병행 없음. Provider 는 **인터페이스 타입**을 노출합니다.

### 이력 보관 90일

`RetentionPolicy` 를 시각 주입 가능한 순수 함수로 분리했습니다 — 내부에서 `DateTime.now()` 를 부르면 경계 조건을 테스트할 수 없습니다.

### 테스트 24건 — 계약 테스트

Drift 구현이 아니라 **인터페이스가 약속한 동작**을 검증합니다 (docs/04-CONVENTIONS.md — "Drift 자체를 믿는다"). 이 테스트를 통과하는 구현이면 화면이 기대한 대로 동작합니다.

특히 넣은 것:
- 저장된 적 없는 장소는 `unknown` (이게 깨지면 앱 시작 직후 오알림)
- **재부팅 시나리오** — 저장된 `outside` 가 살아남는지
- `setEnabled` 가 장소를 지우지 않는지 (F1.7)
- 90일 경계 (89일 보존 / 91일 삭제)

### 기타

- `analysis_options.yaml` — `custom_lint`(riverpod_lint) 플러그인, `avoid_print`
- `.gitignore` — `*.g.dart` · `*.freezed.dart` 제외. 내부망이라 로컬 생성이 불가하고 CI 가 만듭니다

## 범위 제외

화면 · 지도 · 백그라운드 서비스 · 플랫폼 채널. 백그라운드는 Phase 0 스파이크 S-1(패키지 선정) 결과 후 착수합니다.

## 검증

이번 PR 은 **의존성이 많이 추가**됐습니다 (drift · riverpod · uuid 계열 9종). 로컬에서 `pub get` 이 불가하므로 CI 결과가 유일한 검증입니다. 실패하면 의존성을 나눠서 재시도합니다.
