### PR TITLE
위치 목록·등록·편집 화면 구현 (지도 제외)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -5,14 +5,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../core/domain/alert_direction.dart';
-import '../core/theme/app_spacing.dart';
-import '../core/theme/app_typography.dart';
+import '../features/ads/presentation/ads_providers.dart';
 import '../features/alert/domain/alert_controller.dart';
 import '../features/alert/presentation/alert_controller_provider.dart';
 import '../features/alert/presentation/alert_dismissed_screen.dart';
 import '../features/alert/presentation/alert_screen.dart';
-import '../features/ads/presentation/ads_providers.dart';
 import '../features/permission/presentation/onboarding_screen.dart';
+import '../features/places/domain/alert_place.dart';
+import '../features/places/presentation/place_form_screen.dart';
+import '../features/places/presentation/place_list_screen.dart';
 
 /// 앱 라우팅 (docs/02-ARCHITECTURE.md)
 ///
@@ -23,6 +24,8 @@ abstract final class AppRoutes {
   static const home = '/';
   static const alert = '/alert';
   static const alertDismissed = '/alert/dismissed';
+  static const placeNew = '/places/new';
+  static const placeEdit = '/places/edit';
 }
 
 GoRouter createRouter() {
@@ -36,7 +39,19 @@ GoRouter createRouter() {
       ),
       GoRoute(
         path: AppRoutes.home,
-        builder: (context, state) => const _HomePlaceholder(),
+        builder: (context, state) => const _HomeRoute(),
+      ),
+      GoRoute(
+        path: AppRoutes.placeNew,
+        builder: (context, state) =>
+            PlaceFormScreen(onSaved: () => context.go(AppRoutes.home)),
+      ),
+      GoRoute(
+        path: AppRoutes.placeEdit,
+        builder: (context, state) => PlaceFormScreen(
+          existing: state.extra as AlertPlace?,
+          onSaved: () => context.go(AppRoutes.home),
+        ),
       ),
       GoRoute(
         path: AppRoutes.alert,
@@ -110,48 +125,35 @@ class _AlertRoute extends ConsumerWidget {
   }
 }
 
-/// 메인 화면은 아직 구현 전이다 (docs/11-ROADMAP.md Phase 1)
-class _HomePlaceholder extends ConsumerWidget {
-  const _HomePlaceholder();
+/// 메인 화면 — 지도가 붙기 전까지 위치 목록이 홈이다 (docs/11-ROADMAP.md).
+///
+/// 지도 화면이 생기면 목록은 지도 위 시트로 옮겨간다.
+class _HomeRoute extends ConsumerWidget {
+  const _HomeRoute();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(Icons.map_outlined, size: 64),
-            const SizedBox(height: AppSpacing.sm),
-            Text('EarLocAlert', style: AppTypography.screenTitle),
-            const SizedBox(height: AppSpacing.xs),
-            Text('지도 화면 준비 중', style: AppTypography.caption),
-            const SizedBox(height: AppSpacing.lg),
-            // 백그라운드 감시 연결 전까지 알림 흐름을 확인하는 수단.
-            // 지오펜스 연동(S-1 스파이크 이후)이 끝나면 제거한다.
-            OutlinedButton(
-              onPressed: () async {
-                await ref
-                    .read(activeAlertProvider.notifier)
-                    .fire(
-                      AlertRequest(
-                        placeId: 'preview',
-                        placeName: '테스트 장소',
-                        direction: AlertDirection.enter,
-                        soundEnabled: true,
-                        occurredAt: DateTime.now().toUtc(),
-                      ),
-                    );
-                // 사용자가 해제할 때쯤 광고가 준비되어 있게 미리 불러둔다.
-                // 실패해도 아무 일도 일어나지 않는다.
-                unawaited(_preloadAd(ref));
-                if (context.mounted) context.go(AppRoutes.alert);
-              },
-              child: const Text('알림 화면 미리보기'),
-            ),
-          ],
-        ),
-      ),
+    return PlaceListScreen(
+      onAddPlace: () => context.go(AppRoutes.placeNew),
+      onEditPlace: (place) => context.go(AppRoutes.placeEdit, extra: place),
+      // 백그라운드 감시 연결 전까지 알림 흐름을 확인하는 수단 (S-4·S-5).
+      // 지오펜스 연동이 끝나면 제거한다.
+      onPreviewAlert: () async {
+        await ref
+            .read(activeAlertProvider.notifier)
+            .fire(
+              AlertRequest(
+                placeId: 'preview',
+                placeName: '테스트 장소',
+                direction: AlertDirection.enter,
+                soundEnabled: true,
+                occurredAt: DateTime.now().toUtc(),
+              ),
+            );
+        // 사용자가 해제할 때쯤 광고가 준비되어 있게 미리 불러둔다
+        unawaited(_preloadAd(ref));
+        if (context.mounted) context.go(AppRoutes.alert);
+      },
     );
   }
 }

--- a/lib/features/places/domain/place_validator.dart
+++ b/lib/features/places/domain/place_validator.dart
@@ -1,0 +1,48 @@
+/// 장소 입력 검증 (docs/01-REQUIREMENTS.md F1)
+///
+/// 순수 로직 — 화면 없이 테스트한다.
+enum PlaceValidationError {
+  /// 이름이 비어 있다
+  emptyName,
+
+  /// 반경이 허용 범위(50~2000m)를 벗어났다 (F1.4)
+  radiusOutOfRange,
+
+  /// 좌표가 유효 범위를 벗어났다
+  invalidCoordinates,
+
+  /// 등록 상한에 도달했다 — iOS OS 제한 20개 (docs/05-PLATFORM.md)
+  limitReached,
+}
+
+abstract final class PlaceValidator {
+  static const int minRadiusMeters = 50;
+  static const int maxRadiusMeters = 2000;
+
+  /// iOS 지오펜스 상한. **OS 제한이며 우회 방법이 없다.**
+  /// 플랫폼 공통으로 같은 상한을 적용한다 — 기기를 바꿔도 동작이 같아야 한다.
+  static const int maxPlaces = 20;
+
+  static List<PlaceValidationError> validate({
+    required String name,
+    required int radiusMeters,
+    required double latitude,
+    required double longitude,
+    required int currentCount,
+
+    /// 수정이면 상한 검사를 건너뛴다 — 이미 등록된 장소다
+    required bool isNew,
+  }) {
+    return [
+      if (name.trim().isEmpty) PlaceValidationError.emptyName,
+      if (radiusMeters < minRadiusMeters || radiusMeters > maxRadiusMeters)
+        PlaceValidationError.radiusOutOfRange,
+      if (latitude < -90 ||
+          latitude > 90 ||
+          longitude < -180 ||
+          longitude > 180)
+        PlaceValidationError.invalidCoordinates,
+      if (isNew && currentCount >= maxPlaces) PlaceValidationError.limitReached,
+    ];
+  }
+}

--- a/lib/features/places/presentation/place_form_screen.dart
+++ b/lib/features/places/presentation/place_form_screen.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/domain/alert_direction.dart';
+import '../../../core/theme/app_spacing.dart';
+import '../../../core/theme/app_typography.dart';
+import '../domain/alert_place.dart';
+import '../domain/place_validator.dart';
+import 'place_list_controller.dart';
+import 'place_list_screen.dart' show placeErrorMessage;
+
+/// 장소 등록/편집 폼 (docs/06-UX.md)
+///
+/// 좌표 직접 입력은 **지도 연결 전 임시 수단**이다. Google Maps API 키가
+/// 준비되면 "지도에서 선택"으로 교체한다 — 이름·반경·방향·소리는 그대로다.
+class PlaceFormScreen extends ConsumerStatefulWidget {
+  const PlaceFormScreen({this.existing, this.onSaved, super.key});
+
+  /// null 이면 신규 등록
+  final AlertPlace? existing;
+  final VoidCallback? onSaved;
+
+  @override
+  ConsumerState<PlaceFormScreen> createState() => _PlaceFormScreenState();
+}
+
+class _PlaceFormScreenState extends ConsumerState<PlaceFormScreen> {
+  late final _name = TextEditingController(text: widget.existing?.name ?? '');
+  late final _latitude = TextEditingController(
+    text: widget.existing?.latitude.toString() ?? '',
+  );
+  late final _longitude = TextEditingController(
+    text: widget.existing?.longitude.toString() ?? '',
+  );
+
+  late double _radius = (widget.existing?.radiusMeters ?? 100).toDouble();
+  late AlertDirection _direction =
+      widget.existing?.direction ?? AlertDirection.enter;
+  late bool _soundEnabled = widget.existing?.soundEnabled ?? true;
+
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _latitude.dispose();
+    _longitude.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isNew = widget.existing == null;
+
+    return Scaffold(
+      appBar: AppBar(title: Text(isNew ? '장소 등록' : '장소 편집')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          children: [
+            TextField(
+              controller: _name,
+              decoration: const InputDecoration(
+                labelText: '이름',
+                hintText: '예: 내릴 정류장, 약속 장소',
+              ),
+              textInputAction: TextInputAction.next,
+            ),
+            const SizedBox(height: AppSpacing.md),
+
+            // 지도 연결 전 임시 입력. 사용자 안내를 명시한다
+            Text('위치 좌표', style: AppTypography.caption),
+            const SizedBox(height: AppSpacing.xs),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _latitude,
+                    decoration: const InputDecoration(labelText: '위도'),
+                    keyboardType: const TextInputType.numberWithOptions(
+                      decimal: true,
+                      signed: true,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.xs),
+                Expanded(
+                  child: TextField(
+                    controller: _longitude,
+                    decoration: const InputDecoration(labelText: '경도'),
+                    keyboardType: const TextInputType.numberWithOptions(
+                      decimal: true,
+                      signed: true,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text('지도에서 선택하는 기능은 준비 중입니다', style: AppTypography.caption),
+            const SizedBox(height: AppSpacing.md),
+
+            // 반경 — 슬라이더 값이 즉시 보여야 한다.
+            // 지도가 붙으면 반경 원이 실시간으로 함께 커진다 (docs/06-UX.md)
+            Text(
+              '알림 반경 ${_radius.round()}m',
+              style: AppTypography.body.copyWith(fontWeight: FontWeight.w600),
+            ),
+            Slider(
+              value: _radius,
+              min: PlaceValidator.minRadiusMeters.toDouble(),
+              max: PlaceValidator.maxRadiusMeters.toDouble(),
+              divisions: 39,
+              onChanged: (value) => setState(() => _radius = value),
+            ),
+            const SizedBox(height: AppSpacing.md),
+
+            Text('알림 시점', style: AppTypography.caption),
+            const SizedBox(height: AppSpacing.xs),
+            SegmentedButton<AlertDirection>(
+              segments: const [
+                ButtonSegment(
+                  value: AlertDirection.enter,
+                  icon: Icon(Icons.login_outlined),
+                  label: Text('도착'),
+                ),
+                ButtonSegment(
+                  value: AlertDirection.exit,
+                  icon: Icon(Icons.logout_outlined),
+                  label: Text('출발'),
+                ),
+                ButtonSegment(
+                  value: AlertDirection.both,
+                  icon: Icon(Icons.sync_alt_outlined),
+                  label: Text('둘 다'),
+                ),
+              ],
+              selected: {_direction},
+              onSelectionChanged: (selection) =>
+                  setState(() => _direction = selection.first),
+            ),
+            const SizedBox(height: AppSpacing.md),
+
+            SwitchListTile(
+              title: Text('이어폰 소리 알림', style: AppTypography.body),
+              subtitle: Text(
+                '블루투스 이어폰이 연결된 경우에만 소리가 납니다.\n스피커로는 절대 소리가 나지 않습니다.',
+                style: AppTypography.caption,
+              ),
+              value: _soundEnabled,
+              onChanged: (value) => setState(() => _soundEnabled = value),
+              contentPadding: EdgeInsets.zero,
+            ),
+            const SizedBox(height: AppSpacing.lg),
+
+            FilledButton(
+              onPressed: _saving ? null : _save,
+              child: Text(isNew ? '등록' : '저장'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _save() async {
+    setState(() => _saving = true);
+
+    final latitude = double.tryParse(_latitude.text.trim());
+    final longitude = double.tryParse(_longitude.text.trim());
+
+    final errors = latitude == null || longitude == null
+        ? [PlaceValidationError.invalidCoordinates]
+        : await ref
+              .read(placeActionsProvider.notifier)
+              .save(
+                id: widget.existing?.id,
+                name: _name.text,
+                latitude: latitude,
+                longitude: longitude,
+                radiusMeters: _radius.round(),
+                direction: _direction,
+                soundEnabled: _soundEnabled,
+              );
+
+    if (!mounted) return;
+    setState(() => _saving = false);
+
+    if (errors.isEmpty) {
+      widget.onSaved?.call();
+      return;
+    }
+
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(placeErrorMessage(errors.first))));
+  }
+}

--- a/lib/features/places/presentation/place_list_controller.dart
+++ b/lib/features/places/presentation/place_list_controller.dart
@@ -1,0 +1,87 @@
+// Ref 는 riverpod_annotation 이 아니라 flutter_riverpod 이 제공한다
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/di/providers.dart';
+import '../../../core/domain/alert_direction.dart';
+import '../../../core/domain/id_generator.dart';
+import '../domain/alert_place.dart';
+import '../domain/place_validator.dart';
+
+part 'place_list_controller.g.dart';
+
+/// 위치 목록 스트림 (docs/04-CONVENTIONS.md — 화면 데이터는 Provider 에)
+@riverpod
+Stream<List<AlertPlace>> placeList(Ref ref) {
+  return ref.watch(placeRepositoryProvider).watchAll();
+}
+
+/// 위치 조작 컨트롤러
+@riverpod
+class PlaceActions extends _$PlaceActions {
+  @override
+  void build() {}
+
+  /// 저장. 검증 오류가 있으면 저장하지 않고 오류 목록을 반환한다.
+  Future<List<PlaceValidationError>> save({
+    String? id,
+    required String name,
+    required double latitude,
+    required double longitude,
+    required int radiusMeters,
+    required AlertDirection direction,
+    required bool soundEnabled,
+  }) async {
+    final repo = ref.read(placeRepositoryProvider);
+    final isNew = id == null;
+
+    final errors = PlaceValidator.validate(
+      name: name,
+      radiusMeters: radiusMeters,
+      latitude: latitude,
+      longitude: longitude,
+      currentCount: await repo.count(),
+      isNew: isNew,
+    );
+    if (errors.isNotEmpty) return errors;
+
+    final existing = isNew ? null : await repo.findById(id);
+    await repo.save(
+      AlertPlace(
+        // 저장 전에 앱이 식별자를 만든다 (docs/03-DOMAIN.md)
+        id: id ?? IdGenerator.generate(),
+        name: name.trim(),
+        latitude: latitude,
+        longitude: longitude,
+        radiusMeters: radiusMeters,
+        direction: direction,
+        soundEnabled: soundEnabled,
+        enabled: existing?.enabled ?? true,
+        createdAt: existing?.createdAt ?? DateTime.now().toUtc(),
+      ),
+    );
+    return const [];
+  }
+
+  /// 활성/비활성 토글 (F1.7) — 삭제하지 않고 잠시 끄는 수단
+  Future<void> setEnabled(String id, {required bool enabled}) {
+    return ref.read(placeRepositoryProvider).setEnabled(id, enabled: enabled);
+  }
+
+  /// 삭제. 되돌리기(undo)를 위해 삭제된 장소를 반환한다.
+  Future<AlertPlace?> delete(String id) async {
+    final repo = ref.read(placeRepositoryProvider);
+    final place = await repo.findById(id);
+    if (place == null) return null;
+
+    await repo.delete(id);
+    // 장소가 사라지면 지오펜스 상태도 함께 지운다 (docs/03-DOMAIN.md)
+    await ref.read(geofenceStateRepositoryProvider).remove(id);
+    return place;
+  }
+
+  /// undo — 삭제했던 장소를 그대로 되살린다
+  Future<void> restore(AlertPlace place) {
+    return ref.read(placeRepositoryProvider).save(place);
+  }
+}

--- a/lib/features/places/presentation/place_list_screen.dart
+++ b/lib/features/places/presentation/place_list_screen.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/domain/alert_direction.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_semantic_colors.dart';
+import '../../../core/theme/app_spacing.dart';
+import '../../../core/theme/app_typography.dart';
+import '../domain/alert_place.dart';
+import '../domain/place_validator.dart';
+import 'place_list_controller.dart';
+
+/// 위치 목록 화면 (docs/06-UX.md)
+///
+/// 활성 상태를 **배경 반전**으로 표현한다 — 어두운 목록 안의 밝은 카드.
+/// 참조 미감(다크 핀테크)의 선택 표현을 그대로 따른다.
+class PlaceListScreen extends ConsumerWidget {
+  const PlaceListScreen({
+    required this.onAddPlace,
+    this.onEditPlace,
+    this.onPreviewAlert,
+    super.key,
+  });
+
+  final VoidCallback onAddPlace;
+  final void Function(AlertPlace place)? onEditPlace;
+
+  /// 알림 흐름 수동 확인 (실기기 스파이크 S-4·S-5 용).
+  /// 지오펜스 연동이 끝나면 제거한다 (docs/11-ROADMAP.md).
+  final VoidCallback? onPreviewAlert;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final placesAsync = ref.watch(placeListProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('내 장소'),
+        actions: [
+          if (onPreviewAlert != null)
+            IconButton(
+              onPressed: onPreviewAlert,
+              icon: const Icon(Icons.notifications_active_outlined),
+              tooltip: '알림 미리보기',
+            ),
+        ],
+      ),
+      body: placesAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) =>
+            Center(child: Text('장소를 불러오지 못했습니다', style: AppTypography.caption)),
+        data: (places) => places.isEmpty
+            ? _EmptyState(onAddPlace: onAddPlace)
+            : _PlaceList(places: places, onEditPlace: onEditPlace),
+      ),
+      floatingActionButton: placesAsync.valueOrNull?.isEmpty ?? true
+          ? null
+          : FloatingActionButton(
+              onPressed: onAddPlace,
+              child: const Icon(Icons.add_outlined),
+            ),
+    );
+  }
+}
+
+/// 빈 상태 — 앱 첫인상을 결정한다.
+///
+/// "장소가 없다"가 아니라 **무엇을 하면 되는지**를 말한다.
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.onAddPlace});
+
+  final VoidCallback onAddPlace;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Icon(
+            Icons.add_location_alt_outlined,
+            size: 64,
+            color: AppColors.textSecondary,
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Text(
+            '첫 장소를 등록해보세요',
+            style: AppTypography.screenTitle,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            '내릴 정류장, 약속 장소, 집 —\n도착하거나 떠날 때 조용히 알려드립니다.',
+            style: AppTypography.caption,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          FilledButton(onPressed: onAddPlace, child: const Text('장소 등록')),
+        ],
+      ),
+    );
+  }
+}
+
+class _PlaceList extends ConsumerWidget {
+  const _PlaceList({required this.places, this.onEditPlace});
+
+  final List<AlertPlace> places;
+  final void Function(AlertPlace place)? onEditPlace;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListView.separated(
+      padding: const EdgeInsets.all(AppSpacing.sm),
+      itemCount: places.length,
+      separatorBuilder: (_, _) => const SizedBox(height: AppSpacing.xs),
+      itemBuilder: (context, index) {
+        final place = places[index];
+        return _PlaceCard(
+          place: place,
+          onTap: () => onEditPlace?.call(place),
+          onToggle: (enabled) => ref
+              .read(placeActionsProvider.notifier)
+              .setEnabled(place.id, enabled: enabled),
+          onDelete: () => _deleteWithUndo(context, ref, place),
+        );
+      },
+    );
+  }
+
+  /// 삭제는 실수를 되돌릴 수 있어야 한다
+  Future<void> _deleteWithUndo(
+    BuildContext context,
+    WidgetRef ref,
+    AlertPlace place,
+  ) async {
+    final actions = ref.read(placeActionsProvider.notifier);
+    final deleted = await actions.delete(place.id);
+    if (deleted == null || !context.mounted) return;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('\'${deleted.name}\' 삭제됨'),
+        action: SnackBarAction(
+          label: '되돌리기',
+          onPressed: () => actions.restore(deleted),
+        ),
+      ),
+    );
+  }
+}
+
+class _PlaceCard extends StatelessWidget {
+  const _PlaceCard({
+    required this.place,
+    required this.onTap,
+    required this.onToggle,
+    required this.onDelete,
+  });
+
+  final AlertPlace place;
+  final VoidCallback onTap;
+  final ValueChanged<bool> onToggle;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = Theme.of(context).extension<AppSemanticColors>()!;
+    final enabled = place.enabled;
+
+    // 활성 = 반전 카드 (docs/06-UX.md — 선택 상태는 밝은 배경으로 반전)
+    final background = enabled ? AppColors.bgInverse : AppColors.bgSurface;
+    final foreground = enabled
+        ? AppColors.textOnInverse
+        : AppColors.textPrimary;
+    final secondary = enabled
+        ? AppColors.textOnInverse
+        : AppColors.textSecondary;
+
+    final (
+      directionIcon,
+      directionLabel,
+      directionColor,
+    ) = switch (place.direction) {
+      AlertDirection.enter => (
+        Icons.login_outlined,
+        '도착 알림',
+        semantic.alertEnter,
+      ),
+      AlertDirection.exit => (
+        Icons.logout_outlined,
+        '출발 알림',
+        semantic.alertExit,
+      ),
+      AlertDirection.both => (
+        Icons.sync_alt_outlined,
+        '도착·출발',
+        semantic.alertEnter,
+      ),
+    };
+
+    return Material(
+      color: background,
+      borderRadius: BorderRadius.circular(AppRadius.card),
+      child: InkWell(
+        onTap: onTap,
+        onLongPress: onDelete,
+        borderRadius: BorderRadius.circular(AppRadius.card),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.sm),
+          child: Row(
+            children: [
+              Icon(directionIcon, color: directionColor),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      place.name,
+                      style: AppTypography.body.copyWith(
+                        color: foreground,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      '$directionLabel · 반경 ${place.radiusMeters}m',
+                      style: AppTypography.caption.copyWith(color: secondary),
+                    ),
+                  ],
+                ),
+              ),
+              // 활성 토글은 삭제와 분리한다 (F1.7)
+              Switch(value: enabled, onChanged: onToggle),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 검증 오류를 사용자 문구로 바꾼다
+String placeErrorMessage(PlaceValidationError error) => switch (error) {
+  PlaceValidationError.emptyName => '이름을 입력해주세요',
+  PlaceValidationError.radiusOutOfRange =>
+    '반경은 ${PlaceValidator.minRadiusMeters}m ~ ${PlaceValidator.maxRadiusMeters}m 사이여야 합니다',
+  PlaceValidationError.invalidCoordinates => '위치 좌표가 올바르지 않습니다',
+  PlaceValidationError.limitReached =>
+    '장소는 최대 ${PlaceValidator.maxPlaces}개까지 등록할 수 있습니다',
+};

--- a/test/features/places/place_validator_test.dart
+++ b/test/features/places/place_validator_test.dart
@@ -1,0 +1,70 @@
+import 'package:ear_loc_alert/features/places/domain/place_validator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  List<PlaceValidationError> validate({
+    String name = '장소',
+    int radius = 100,
+    double lat = 37.5,
+    double lng = 127.0,
+    int count = 0,
+    bool isNew = true,
+  }) {
+    return PlaceValidator.validate(
+      name: name,
+      radiusMeters: radius,
+      latitude: lat,
+      longitude: lng,
+      currentCount: count,
+      isNew: isNew,
+    );
+  }
+
+  group('장소 검증 (F1)', () {
+    test('정상 입력은 오류가 없다', () {
+      expect(validate(), isEmpty);
+    });
+
+    test('빈 이름(공백 포함)은 거부한다', () {
+      expect(validate(name: '  '), contains(PlaceValidationError.emptyName));
+    });
+
+    test('반경 경계 — 50 과 2000 은 허용, 밖은 거부 (F1.4)', () {
+      expect(validate(radius: 50), isEmpty);
+      expect(validate(radius: 2000), isEmpty);
+      expect(
+        validate(radius: 49),
+        contains(PlaceValidationError.radiusOutOfRange),
+      );
+      expect(
+        validate(radius: 2001),
+        contains(PlaceValidationError.radiusOutOfRange),
+      );
+    });
+
+    test('좌표 범위 밖은 거부한다', () {
+      expect(
+        validate(lat: 91),
+        contains(PlaceValidationError.invalidCoordinates),
+      );
+      expect(
+        validate(lng: -181),
+        contains(PlaceValidationError.invalidCoordinates),
+      );
+    });
+
+    test('신규 등록은 20개 상한에 막힌다 (docs/05-PLATFORM.md)', () {
+      expect(validate(count: 20), contains(PlaceValidationError.limitReached));
+      expect(validate(count: 19), isEmpty);
+    });
+
+    test('기존 장소 수정은 상한과 무관하다', () {
+      expect(validate(count: 20, isNew: false), isEmpty);
+    });
+
+    test('오류는 동시에 여러 개 보고된다', () {
+      final errors = validate(name: '', radius: 10);
+      expect(errors, hasLength(2));
+    });
+  });
+}


### PR DESCRIPTION
## 개요

위치 목록·등록·편집 화면 (지도 제외). 지도는 Google Maps 키 발급 후 좌표 입력만 교체하면 됩니다.

- 관련 이슈: https://github.com/Cassiiopeia/EarLocAlert/issues/61

- 활성 = 반전 카드 (docs/06-UX.md), 방향은 색+아이콘+텍스트
- 활성 토글은 삭제와 분리 (F1.7), 삭제는 스낵바 undo
- PlaceValidator: 이름·반경(50~2000)·좌표·20개 상한(iOS OS 제한)
- 장소 삭제 시 지오펜스 상태 동반 제거
- 홈을 위치 목록으로 교체
- 검증 테스트 7건

⚠️ PR #60 과 router.dart 충돌 가능 — 먼저 머지된 쪽 이후 rebase 필요
