### PR TITLE
배포 워크플로우에 build_runner 코드 생성 단계 누락

### DIFF
--- a/.github/workflows/PROJECT-FLUTTER-ANDROID-PLAYSTORE-CICD.yaml
+++ b/.github/workflows/PROJECT-FLUTTER-ANDROID-PLAYSTORE-CICD.yaml
@@ -278,6 +278,10 @@ jobs:
           flutter clean
           flutter pub get
 
+          # freezed·riverpod·drift 코드 생성 — 이게 없으면 릴리스 빌드가
+          # undefined getter 로 실패한다 (#67)
+          dart run build_runner build --delete-conflicting-outputs
+
           # local.properties에 버전 정보 추가 (Flutter 플래그가 무시되는 문제 해결)
           echo "🔧 local.properties에 버전 정보 설정..."
 

--- a/.github/workflows/PROJECT-FLUTTER-ANDROID-SYNOLOGY-CICD.yaml
+++ b/.github/workflows/PROJECT-FLUTTER-ANDROID-SYNOLOGY-CICD.yaml
@@ -115,6 +115,10 @@ jobs:
           echo "Dependencies installed"
           ls -la
 
+      # freezed·riverpod·drift 코드 생성 — 없으면 릴리스 빌드 실패 (#67)
+      - name: 코드 생성 (build_runner)
+        run: dart run build_runner build --delete-conflicting-outputs
+
       # Gradle 셋업
       - name: Setup Gradle
         working-directory: android

--- a/.github/workflows/PROJECT-FLUTTER-IOS-TESTFLIGHT.yaml
+++ b/.github/workflows/PROJECT-FLUTTER-IOS-TESTFLIGHT.yaml
@@ -178,6 +178,10 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      # freezed·riverpod·drift 코드 생성 — 없으면 릴리스 빌드 실패 (#67)
+      - name: 코드 생성 (build_runner)
+        run: dart run build_runner build --delete-conflicting-outputs
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -331,6 +335,10 @@ jobs:
 
       - name: Install dependencies
         run: flutter pub get
+
+      # freezed·riverpod·drift 코드 생성 — 없으면 릴리스 빌드 실패 (#67)
+      - name: 코드 생성 (build_runner)
+        run: dart run build_runner build --delete-conflicting-outputs
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## 개요

Play Store 배포가 AAB 빌드에서 실패하는 문제를 수정합니다 (run 30831981242 — `Error: The getter 'latitude' isn't defined for the type 'PositionSample'`).

- https://github.com/Cassiiopeia/EarLocAlert/issues/67

## 원인

배포 워크플로우 3종(PLAYSTORE·SYNOLOGY·iOS)에 **build_runner 코드 생성 단계가 없다.** PR-CI 에는 있으나 배포 쪽에는 누락됐고, freezed/riverpod/drift codegen 모델(#43~) 도입 후 첫 배포 시도(#63·#65 머지 후)에서 드러났다. PLAYSTORE 는 빌드 직전 `flutter clean` 까지 수행해 잔존 산출물도 없다.

## 변경

- 각 워크플로우의 `flutter pub get` 직후 `dart run build_runner build --delete-conflicting-outputs` 추가
- iOS 워크플로우는 서명 자산 갱신(#51) 후를 대비해 함께 수정

## 검증

- 3개 YAML `yaml.safe_load` 파싱 통과
- 머지 후 deploy 재트리거로 실배포 확인 예정 (후속 댓글로 결과 기록)
