### PR TITLE
지도 위치 검색 추가 (#72)

### DIFF
--- a/android/app/src/main/kotlin/kr/suhsaechan/ear_loc_alert/MainActivity.kt
+++ b/android/app/src/main/kotlin/kr/suhsaechan/ear_loc_alert/MainActivity.kt
@@ -1,5 +1,34 @@
 package kr.suhsaechan.ear_loc_alert
 
+import android.content.pm.PackageManager
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        // Google Maps API 키를 Dart(장소 검색 REST)에 넘긴다.
+        // 키의 단일 소스는 .env → 매니페스트 주입이고, 여기서는 그 값을
+        // 도로 읽기만 한다 (docs/08-OPERATIONS.md). 키 없이 빌드되면 빈
+        // 문자열이 가고, Dart 쪽이 검색을 조용히 비활성화한다.
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "kr.suhsaechan.ear_loc_alert/maps_api_key",
+        ).setMethodCallHandler { call, result ->
+            if (call.method == "getMapsApiKey") {
+                val info = packageManager.getApplicationInfo(
+                    packageName,
+                    PackageManager.GET_META_DATA,
+                )
+                result.success(
+                    info.metaData?.getString("com.google.android.geo.API_KEY") ?: "",
+                )
+            } else {
+                result.notImplemented()
+            }
+        }
+    }
+}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -25,6 +25,23 @@ import native_geofence
         GeneratedPluginRegistrant.register(with: registry)
     }
     GeneratedPluginRegistrant.register(with: self)
+
+    // Google Maps API 키를 Dart(장소 검색 REST)에 넘긴다.
+    // 키의 단일 소스는 .env → Info.plist 주입이고, 여기서는 그 값을
+    // 도로 읽기만 한다 (docs/08-OPERATIONS.md).
+    if let controller = window?.rootViewController as? FlutterViewController {
+      FlutterMethodChannel(
+        name: "kr.suhsaechan.ear_loc_alert/maps_api_key",
+        binaryMessenger: controller.binaryMessenger
+      ).setMethodCallHandler { call, result in
+        guard call.method == "getMapsApiKey" else {
+          result(FlutterMethodNotImplemented)
+          return
+        }
+        result(Bundle.main.object(forInfoDictionaryKey: "MapsApiKey") as? String ?? "")
+      }
+    }
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -15,6 +15,7 @@ import '../features/places/domain/alert_place.dart';
 import '../features/places/presentation/place_form_screen.dart';
 import '../features/places/presentation/place_map_home_screen.dart';
 import '../features/places/presentation/place_map_picker_screen.dart';
+import '../features/places/presentation/place_search_provider.dart';
 import 'home_status_provider.dart';
 
 /// 앱 라우팅 (docs/02-ARCHITECTURE.md)
@@ -61,11 +62,8 @@ GoRouter createRouter() {
       ),
       GoRoute(
         path: AppRoutes.placeMap,
-        builder: (context, state) => PlaceMapPickerScreen(
-          args: state.extra! as MapPickArgs,
-          // 선택 결과를 push 를 기다리던 폼에게 돌려준다
-          onPicked: (result) => context.pop(result),
-        ),
+        builder: (context, state) =>
+            _MapPickerRoute(args: state.extra! as MapPickArgs),
       ),
       GoRoute(
         path: AppRoutes.alert,
@@ -80,6 +78,23 @@ GoRouter createRouter() {
       ),
     ],
   );
+}
+
+/// 지도 위치 선택 라우트 — 검색 서비스를 조립해 내려준다 (issue #72).
+class _MapPickerRoute extends ConsumerWidget {
+  const _MapPickerRoute({required this.args});
+
+  final MapPickArgs args;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return PlaceMapPickerScreen(
+      args: args,
+      searchService: ref.watch(placeSearchServiceProvider),
+      // 선택 결과를 push 를 기다리던 폼에게 돌려준다
+      onPicked: (result) => context.pop(result),
+    );
+  }
 }
 
 /// 지도 화면을 열고 선택 결과를 기다린다.

--- a/lib/features/places/data/google_place_search_service.dart
+++ b/lib/features/places/data/google_place_search_service.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../domain/place_search.dart';
+import 'maps_api_key_channel.dart';
+
+/// Google Places API (New) Text Search 구현 (issue #72)
+///
+/// SDK 대신 REST 를 직접 부른다 — 검색 하나에 플러그인을 더 들이는 것보다
+/// 요청 한 개를 만드는 쪽이 작고, 응답 파싱을 순수 함수로 분리해
+/// 실기기 없이 테스트할 수 있다.
+///
+/// 키는 네이티브에 주입된 값을 채널로 읽는다. 키가 없으면
+/// [PlaceSearchUnavailable] — 검색만 죽고 앱은 계속 동작해야 한다.
+class GooglePlaceSearchService implements PlaceSearchService {
+  GooglePlaceSearchService({Future<String?> Function()? apiKeyLoader})
+    : _apiKeyLoader = apiKeyLoader ?? MapsApiKeyChannel.read;
+
+  final Future<String?> Function() _apiKeyLoader;
+
+  static final _endpoint = Uri.parse(
+    'https://places.googleapis.com/v1/places:searchText',
+  );
+
+  /// null 은 "아직 안 읽음"과 구분되지 않으므로 키 없음은 '' 로 캐시한다
+  String? _cachedKey;
+
+  @override
+  Future<List<PlaceSearchResult>> search(String query) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) return const [];
+
+    final key = _cachedKey ??= (await _apiKeyLoader()) ?? '';
+    if (key.isEmpty) {
+      throw const PlaceSearchUnavailable('Maps API 키가 없다');
+    }
+
+    final client = HttpClient()..connectionTimeout = const Duration(seconds: 8);
+    try {
+      final request = await client.postUrl(_endpoint);
+      request.headers
+        ..contentType = ContentType.json
+        ..set('X-Goog-Api-Key', key)
+        // 필요한 필드만 청구된다 — 마스크를 넓히면 과금 SKU 가 올라간다
+        ..set(
+          'X-Goog-FieldMask',
+          'places.displayName,places.formattedAddress,places.location',
+        );
+      request.write(
+        jsonEncode({'textQuery': trimmed, 'languageCode': 'ko', 'pageSize': 8}),
+      );
+
+      final response = await request.close();
+      final body = await response.transform(utf8.decoder).join();
+
+      if (response.statusCode != HttpStatus.ok) {
+        // 403 = 키 제한에 Places API 가 빠져 있다 (docs/08-OPERATIONS.md)
+        throw PlaceSearchUnavailable('HTTP ${response.statusCode}');
+      }
+      return parseResponse(body);
+    } on PlaceSearchUnavailable {
+      rethrow;
+    } on Object catch (error) {
+      // 네트워크 단절·타임아웃 — 검색 불가로 통일한다
+      throw PlaceSearchUnavailable('$error');
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  /// 응답 파싱 — 순수 함수라 실기기 없이 테스트한다.
+  ///
+  /// 필드가 빠진 항목은 조용히 버린다. 좌표 없는 검색 결과는
+  /// 이 앱에서 쓸모가 없고, 하나가 이상하다고 전체를 실패시키면
+  /// 멀쩡한 결과까지 못 보여준다.
+  static List<PlaceSearchResult> parseResponse(String body) {
+    final decoded = jsonDecode(body);
+    if (decoded is! Map<String, dynamic>) return const [];
+
+    final places = decoded['places'];
+    if (places is! List) return const [];
+
+    final results = <PlaceSearchResult>[];
+    for (final place in places) {
+      if (place is! Map<String, dynamic>) continue;
+
+      final location = place['location'];
+      if (location is! Map<String, dynamic>) continue;
+      final latitude = location['latitude'];
+      final longitude = location['longitude'];
+      if (latitude is! num || longitude is! num) continue;
+
+      final displayName = place['displayName'];
+      final name = displayName is Map<String, dynamic>
+          ? displayName['text']
+          : null;
+
+      results.add(
+        PlaceSearchResult(
+          name: name is String && name.isNotEmpty ? name : '이름 없는 장소',
+          address: place['formattedAddress'] is String
+              ? place['formattedAddress'] as String
+              : '',
+          latitude: latitude.toDouble(),
+          longitude: longitude.toDouble(),
+        ),
+      );
+    }
+    return results;
+  }
+}

--- a/lib/features/places/data/maps_api_key_channel.dart
+++ b/lib/features/places/data/maps_api_key_channel.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/services.dart';
+
+/// 네이티브에 이미 박혀 있는 Google Maps API 키를 읽어온다.
+///
+/// 키의 단일 소스는 `.env` 하나이고, 빌드가 Android 매니페스트와
+/// iOS Info.plist 에 주입한다 (docs/08-OPERATIONS.md). Dart 에서 키가
+/// 필요한 곳(장소 검색 REST 호출)은 **그 주입된 값을 도로 읽는다** —
+/// dart-define 같은 두 번째 주입 경로를 만들면 한쪽만 갱신되는 사고가 난다.
+abstract final class MapsApiKeyChannel {
+  static const _channel = MethodChannel(
+    'kr.suhsaechan.ear_loc_alert/maps_api_key',
+  );
+
+  /// 키가 없거나(키 없이 빌드) 채널이 실패하면 null.
+  /// 호출자는 null 이면 검색을 조용히 비활성화한다 — 앱은 계속 동작한다.
+  static Future<String?> read() async {
+    try {
+      final key = await _channel.invokeMethod<String>('getMapsApiKey');
+      if (key == null || key.isEmpty) return null;
+      return key;
+    } on Object {
+      return null;
+    }
+  }
+}

--- a/lib/features/places/domain/place_search.dart
+++ b/lib/features/places/domain/place_search.dart
@@ -1,0 +1,37 @@
+/// 장소 검색 (F1.2 — issue #72 로 전방 배치)
+///
+/// 검색은 **좌표를 얻는 보조 수단**이다. 결과를 저장하지 않고, 선택하면
+/// 지도 카메라를 그리로 옮기는 것까지만 한다 — 최종 위치는 언제나
+/// 사용자가 핀으로 확정한다. 검색 제공자의 좌표를 그대로 믿으면
+/// 출입구 반대편에 지오펜스가 걸리는 일이 생긴다.
+class PlaceSearchResult {
+  const PlaceSearchResult({
+    required this.name,
+    required this.address,
+    required this.latitude,
+    required this.longitude,
+  });
+
+  final String name;
+  final String address;
+  final double latitude;
+  final double longitude;
+}
+
+/// 검색 서비스.
+///
+/// 빈 목록은 "결과 없음"이다. 검색 자체를 못 하는 상태(키 없음·네트워크
+/// 차단)는 [PlaceSearchUnavailable] 로 구분한다 — 화면이 "결과 없음"과
+/// "검색 불가"를 다르게 보여줘야 하기 때문이다.
+abstract interface class PlaceSearchService {
+  Future<List<PlaceSearchResult>> search(String query);
+}
+
+class PlaceSearchUnavailable implements Exception {
+  const PlaceSearchUnavailable(this.reason);
+
+  final String reason;
+
+  @override
+  String toString() => 'PlaceSearchUnavailable: $reason';
+}

--- a/lib/features/places/presentation/place_map_picker_screen.dart
+++ b/lib/features/places/presentation/place_map_picker_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
@@ -6,6 +8,7 @@ import '../../../core/theme/app_semantic_colors.dart';
 import '../../../core/theme/app_spacing.dart';
 import '../../../core/theme/app_typography.dart';
 import '../../../core/theme/map_style.dart';
+import '../domain/place_search.dart';
 import '../domain/place_validator.dart';
 
 /// 지도에서 고른 결과 — 위치와 반경을 함께 돌려준다.
@@ -44,12 +47,21 @@ class MapPickArgs {
 /// 버스에서 한 손으로 조작할 때 이쪽이 정확하고 쉽다. 핀이 손가락에
 /// 가리지도 않는다.
 class PlaceMapPickerScreen extends StatefulWidget {
-  const PlaceMapPickerScreen({required this.args, this.onPicked, super.key});
+  const PlaceMapPickerScreen({
+    required this.args,
+    this.onPicked,
+    this.searchService,
+    super.key,
+  });
 
   final MapPickArgs args;
 
   /// 선택 완료. 라우터가 화면을 닫으며 결과를 돌려준다
   final ValueChanged<MapPickResult>? onPicked;
+
+  /// 장소 검색 (F1.2, issue #72). null 이면 검색창을 그리지 않는다 —
+  /// 지도·핀·저장은 검색 없이도 전부 동작해야 한다
+  final PlaceSearchService? searchService;
 
   /// 지도 초기 위치 — 좌표가 없을 때 쓴다.
   ///
@@ -66,6 +78,28 @@ class _PlaceMapPickerScreenState extends State<PlaceMapPickerScreen> {
   late LatLng _center = _initialCenter;
   late double _radius = widget.args.radiusMeters.toDouble();
 
+  GoogleMapController? _map;
+
+  // ── 검색 상태 ──
+  final _searchController = TextEditingController();
+  final _searchFocus = FocusNode();
+  Timer? _debounce;
+
+  /// 마지막으로 보낸 질의. 늦게 도착한 옛 응답이 새 결과를 덮지 못하게 한다
+  String _inFlightQuery = '';
+  List<PlaceSearchResult> _results = const [];
+  bool _searching = false;
+  bool _searchUnavailable = false;
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _searchController.dispose();
+    _searchFocus.dispose();
+    _map?.dispose();
+    super.dispose();
+  }
+
   LatLng get _initialCenter {
     final latitude = widget.args.latitude;
     final longitude = widget.args.longitude;
@@ -73,6 +107,61 @@ class _PlaceMapPickerScreenState extends State<PlaceMapPickerScreen> {
       return PlaceMapPickerScreen._fallback;
     }
     return LatLng(latitude, longitude);
+  }
+
+  // ── 검색 ────────────────────────────────────────────────────
+
+  void _onQueryChanged(String query) {
+    _debounce?.cancel();
+    if (query.trim().length < 2) {
+      setState(() {
+        _results = const [];
+        _searching = false;
+      });
+      return;
+    }
+    // 타자마다 요청하지 않는다 — 과금 요청 수가 그대로 늘어난다
+    _debounce = Timer(const Duration(milliseconds: 400), () => _search(query));
+  }
+
+  Future<void> _search(String query) async {
+    final service = widget.searchService;
+    if (service == null) return;
+
+    setState(() {
+      _searching = true;
+      _searchUnavailable = false;
+    });
+    _inFlightQuery = query;
+
+    try {
+      final results = await service.search(query);
+      if (!mounted || _inFlightQuery != query) return;
+      setState(() {
+        _results = results;
+        _searching = false;
+      });
+    } on PlaceSearchUnavailable {
+      if (!mounted || _inFlightQuery != query) return;
+      setState(() {
+        _results = const [];
+        _searching = false;
+        _searchUnavailable = true;
+      });
+    }
+  }
+
+  /// 결과를 고르면 **카메라만 옮긴다.** 좌표 확정은 여전히 핀이다 —
+  /// 검색 좌표가 출입구 반대편일 수 있고, 최종 판단은 사용자의 눈이다.
+  void _onResultTapped(PlaceSearchResult result) {
+    _searchFocus.unfocus();
+    setState(() => _results = const []);
+    _map?.animateCamera(
+      CameraUpdate.newLatLngZoom(
+        LatLng(result.latitude, result.longitude),
+        _zoomForRadius(_radius),
+      ),
+    );
   }
 
   @override
@@ -85,6 +174,7 @@ class _PlaceMapPickerScreenState extends State<PlaceMapPickerScreen> {
       body: Stack(
         children: [
           GoogleMap(
+            onMapCreated: (controller) => _map = controller,
             initialCameraPosition: CameraPosition(
               target: _initialCenter,
               zoom: _zoomForRadius(_radius),
@@ -140,6 +230,18 @@ class _PlaceMapPickerScreenState extends State<PlaceMapPickerScreen> {
               ),
             ),
           ),
+
+          // 검색은 지도 위에 얹는다 — 핀·반경 조작을 가리지 않게 상단에만
+          if (widget.searchService != null)
+            _SearchOverlay(
+              controller: _searchController,
+              focusNode: _searchFocus,
+              results: _results,
+              searching: _searching,
+              unavailable: _searchUnavailable,
+              onChanged: _onQueryChanged,
+              onResultTapped: _onResultTapped,
+            ),
         ],
       ),
     );
@@ -153,6 +255,145 @@ class _PlaceMapPickerScreenState extends State<PlaceMapPickerScreen> {
     if (meters <= 300) return 16;
     if (meters <= 800) return 15;
     return 14;
+  }
+}
+
+/// 검색창 + 결과 목록 오버레이
+class _SearchOverlay extends StatelessWidget {
+  const _SearchOverlay({
+    required this.controller,
+    required this.focusNode,
+    required this.results,
+    required this.searching,
+    required this.unavailable,
+    required this.onChanged,
+    required this.onResultTapped,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final List<PlaceSearchResult> results;
+  final bool searching;
+  final bool unavailable;
+  final ValueChanged<String> onChanged;
+  final ValueChanged<PlaceSearchResult> onResultTapped;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      top: 0,
+      left: 0,
+      right: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.sm),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Material(
+              color: AppColors.bgSurface,
+              borderRadius: BorderRadius.circular(AppRadius.pill),
+              child: TextField(
+                controller: controller,
+                focusNode: focusNode,
+                onChanged: onChanged,
+                textInputAction: TextInputAction.search,
+                style: AppTypography.body,
+                decoration: InputDecoration(
+                  hintText: '장소·주소 검색',
+                  hintStyle: AppTypography.caption,
+                  border: InputBorder.none,
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.sm,
+                    vertical: AppSpacing.xs,
+                  ),
+                  prefixIcon: const Icon(Icons.search_outlined, size: 20),
+                  suffixIcon: searching
+                      ? const Padding(
+                          padding: EdgeInsets.all(AppSpacing.xs),
+                          child: SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          ),
+                        )
+                      : controller.text.isEmpty
+                      ? null
+                      : IconButton(
+                          icon: const Icon(Icons.close_outlined, size: 18),
+                          onPressed: () {
+                            controller.clear();
+                            onChanged('');
+                          },
+                        ),
+                ),
+              ),
+            ),
+
+            if (unavailable)
+              Padding(
+                padding: const EdgeInsets.only(top: AppSpacing.xs),
+                child: _SearchMessage('검색을 사용할 수 없습니다 — 지도를 움직여 위치를 맞춰주세요'),
+              )
+            else if (results.isNotEmpty)
+              Container(
+                margin: const EdgeInsets.only(top: AppSpacing.xs),
+                constraints: const BoxConstraints(maxHeight: 280),
+                decoration: BoxDecoration(
+                  color: AppColors.bgSurface,
+                  borderRadius: BorderRadius.circular(AppRadius.small),
+                ),
+                child: ListView.separated(
+                  shrinkWrap: true,
+                  padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+                  itemCount: results.length,
+                  separatorBuilder: (_, _) =>
+                      const Divider(height: 1, color: AppColors.bgElevated),
+                  itemBuilder: (context, index) {
+                    final result = results[index];
+                    return ListTile(
+                      dense: true,
+                      leading: const Icon(Icons.place_outlined, size: 20),
+                      title: Text(
+                        result.name,
+                        style: AppTypography.body,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      subtitle: result.address.isEmpty
+                          ? null
+                          : Text(
+                              result.address,
+                              style: AppTypography.caption,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                      onTap: () => onResultTapped(result),
+                    );
+                  },
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SearchMessage extends StatelessWidget {
+  const _SearchMessage(this.message);
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.sm),
+      decoration: BoxDecoration(
+        color: AppColors.bgSurface,
+        borderRadius: BorderRadius.circular(AppRadius.small),
+      ),
+      child: Text(message, style: AppTypography.caption),
+    );
   }
 }
 

--- a/lib/features/places/presentation/place_search_provider.dart
+++ b/lib/features/places/presentation/place_search_provider.dart
@@ -1,0 +1,11 @@
+// Ref 는 riverpod_annotation 이 아니라 flutter_riverpod 이 제공한다
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../data/google_place_search_service.dart';
+import '../domain/place_search.dart';
+
+part 'place_search_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+PlaceSearchService placeSearchService(Ref ref) => GooglePlaceSearchService();

--- a/test/features/places/place_search_parse_test.dart
+++ b/test/features/places/place_search_parse_test.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+
+import 'package:ear_loc_alert/features/places/data/google_place_search_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Places API (New) Text Search 응답 파싱 (issue #72)
+///
+/// 파싱은 순수 함수라 실기기·네트워크 없이 전부 검증한다.
+void main() {
+  group('검색 응답 파싱', () {
+    test('정상 응답 → 이름·주소·좌표가 그대로 온다', () {
+      final body = jsonEncode({
+        'places': [
+          {
+            'displayName': {'text': '강남역', 'languageCode': 'ko'},
+            'formattedAddress': '서울특별시 강남구 강남대로 지하396',
+            'location': {'latitude': 37.4979, 'longitude': 127.0276},
+          },
+          {
+            'displayName': {'text': '강남역 2호선', 'languageCode': 'ko'},
+            'formattedAddress': '서울특별시 강남구',
+            'location': {'latitude': 37.4981, 'longitude': 127.0278},
+          },
+        ],
+      });
+
+      final results = GooglePlaceSearchService.parseResponse(body);
+
+      expect(results, hasLength(2));
+      expect(results.first.name, '강남역');
+      expect(results.first.address, '서울특별시 강남구 강남대로 지하396');
+      expect(results.first.latitude, closeTo(37.4979, 1e-9));
+      expect(results.first.longitude, closeTo(127.0276, 1e-9));
+    });
+
+    test('결과 없음 — places 필드 자체가 없다', () {
+      // Places API 는 결과가 없으면 빈 객체를 준다
+      expect(GooglePlaceSearchService.parseResponse('{}'), isEmpty);
+    });
+
+    test('좌표 없는 항목은 버리고 나머지는 살린다', () {
+      final body = jsonEncode({
+        'places': [
+          {
+            'displayName': {'text': '좌표 없는 곳'},
+            'formattedAddress': '어딘가',
+            // location 누락
+          },
+          {
+            'displayName': {'text': '멀쩡한 곳'},
+            'formattedAddress': '서울',
+            'location': {'latitude': 37.5, 'longitude': 127.0},
+          },
+        ],
+      });
+
+      final results = GooglePlaceSearchService.parseResponse(body);
+
+      expect(results, hasLength(1));
+      expect(results.first.name, '멀쩡한 곳');
+    });
+
+    test('이름이 없으면 대체 문구, 주소가 없으면 빈 문자열', () {
+      final body = jsonEncode({
+        'places': [
+          {
+            'location': {'latitude': 37.5, 'longitude': 127.0},
+          },
+        ],
+      });
+
+      final results = GooglePlaceSearchService.parseResponse(body);
+
+      expect(results, hasLength(1));
+      expect(results.first.name, '이름 없는 장소');
+      expect(results.first.address, '');
+    });
+
+    test('정수 좌표도 double 로 변환된다', () {
+      final body = jsonEncode({
+        'places': [
+          {
+            'displayName': {'text': '적도 어딘가'},
+            'location': {'latitude': 0, 'longitude': 127},
+          },
+        ],
+      });
+
+      final results = GooglePlaceSearchService.parseResponse(body);
+
+      expect(results.single.latitude, 0.0);
+      expect(results.single.longitude, 127.0);
+    });
+  });
+}


### PR DESCRIPTION
closes #72

## 무엇을

지도 위치 선택 화면에 **장소·주소 검색**을 붙인다 (F1.2 전방 배치). 검색 → 결과 선택 → 카메라 이동 → 핀으로 확정.

## 어떻게

- **Places API (New) Text Search REST 직접 호출** — 검색 하나에 플러그인을 들이지 않는다. FieldMask 를 `displayName,formattedAddress,location` 으로 최소화해 과금 SKU 를 낮게 유지
- **키 경로를 새로 만들지 않았다** — `.env` → 네이티브 주입(매니페스트·Info.plist)된 값을 MethodChannel 로 도로 읽는다. dart-define 같은 두 번째 주입 경로를 만들면 한쪽만 갱신되는 사고가 난다
- 검색창: 400ms 디바운스(과금 요청 수 제어), 2자 미만 무시, 늦게 도착한 옛 응답이 새 결과를 덮지 못하게 질의 토큰 검사
- **결과 선택은 카메라만 옮긴다.** 좌표 확정은 여전히 중앙 핀 — 검색 좌표가 출입구 반대편일 수 있다
- 키 없음·네트워크 차단이면 "검색을 사용할 수 없습니다" 한 줄 — 지도·핀·저장은 그대로 동작
- 파싱은 순수 함수로 분리, 테스트 5건 (정상·결과없음·필드누락·정수좌표)

## 사용자 작업 (검색 활성화에 필요)

Google Cloud 콘솔에서:
1. **Places API (New)** Enable
2. API 키 제한 목록에 **Places API (New)** 추가 (현재 Maps SDK 2개만 허용 중 → 403)

이걸 안 해도 앱은 정상이고 검색창만 "사용할 수 없습니다"로 뜬다.

## 검증

- 로컬 analyze·test 불가(내부망) — PR CI 가 검증한다
- 실기기: 검색 → 선택 → 핀 확정 → 저장 플로우 확인 필요