### PR TITLE
배포 파이프라인 결함 수정 — Release APK 첨부·skip 되던 배포 잡·AAB 경로

### DIFF
--- a/.github/workflows/PROJECT-FLUTTER-ANDROID-PLAYSTORE-CICD.yaml
+++ b/.github/workflows/PROJECT-FLUTTER-ANDROID-PLAYSTORE-CICD.yaml
@@ -517,7 +517,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: android-aab
-          path: ${{ env.FLUTTER_ROOT }}/build/app/outputs/bundle/release/app-release.aab
+          # FLUTTER_ROOT 는 Flutter SDK 설치 경로(/opt/hostedtoolcache/...)라
+          # 산출물이 있는 곳이 아니다. 그 경로를 쓰면 AAB 가 정상 빌드돼도
+          # "No files were found" 로 업로드가 비어 다음 잡이 죽는다.
+          path: ${{ github.workspace }}/build/app/outputs/bundle/release/app-release.aab
           retention-days: 1
 
   deploy-playstore:

--- a/.github/workflows/PROJECT-FLUTTER-ANDROID-SYNOLOGY-CICD.yaml
+++ b/.github/workflows/PROJECT-FLUTTER-ANDROID-SYNOLOGY-CICD.yaml
@@ -199,11 +199,47 @@ jobs:
           path: ./android/app/build/outputs/apk/release/${{ env.PROJECT_NAME }}-v${{ env.VERSION }}-${{ env.SHORT_COMMIT_HASH }}.apk
           retention-days: 1
 
+      # GitHub Release 에 APK 를 붙인다.
+      #
+      # 아티팩트는 1일 뒤 사라지고 로그인해야 받을 수 있다. 실기기에 설치할
+      # APK 는 릴리스에 남아 있어야 한다 (RELEASE-PUBLISH 는 노트만 만들고
+      # 산출물을 붙이지 않는다).
+      #
+      # 두 워크플로우가 main push 로 **동시에** 시작하므로, 릴리스가 아직
+      # 없을 수 있다. 생길 때까지 기다렸다가 붙인다.
+      - name: GitHub Release 에 APK 첨부
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT || github.token }}
+        run: |
+          TAG="v${{ env.VERSION }}"
+          APK="./android/app/build/outputs/apk/release/${{ env.PROJECT_NAME }}-v${{ env.VERSION }}-${{ env.SHORT_COMMIT_HASH }}.apk"
+
+          for i in $(seq 1 30); do
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              echo "릴리스 $TAG 확인"
+              break
+            fi
+            echo "릴리스 $TAG 대기 중... ($i/30)"
+            sleep 10
+          done
+
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            # 릴리스가 끝내 없으면 APK 만이라도 남긴다 — 실패로 배포를 막지 않는다
+            echo "::warning::릴리스 $TAG 를 찾지 못해 APK 를 첨부하지 못했습니다"
+            exit 0
+          fi
+
+          gh release upload "$TAG" "$APK" --clobber
+          echo "✅ $TAG 에 $(basename "$APK") 첨부 완료"
+
   deploy-android:
     name: Deploy Android APK
     runs-on: ubuntu-latest
     needs: build-android
-    if: github.ref == 'refs/heads/deploy'
+    # deploy 브랜치를 걷어내고 develop→main 으로 통일했다.
+    # 트리거만 바꾸고 이 조건을 두면 잡이 조용히 skip 된다.
+    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,14 +1,33 @@
 {
   "metadata": {
-    "lastUpdated": "2026-08-06T06:31:02Z",
-    "currentVersion": "1.2.40",
+    "lastUpdated": "2026-08-06T07:17:31Z",
+    "currentVersion": "1.2.41",
     "projectType": "flutter",
-    "totalReleases": 30,
+    "totalReleases": 31,
     "projectTypes": [
       "flutter"
     ]
   },
   "releases": [
+    {
+      "version": "1.2.41",
+      "project_type": "flutter",
+      "project_types": [
+        "flutter"
+      ],
+      "date": "2026-08-06",
+      "pr_number": 78,
+      "raw_summary": "## [1.2.41]\n\n### 🐛 수정\n- 릴리스 APK 첨부 및 배포 잔재 수정 — main push 에서 skip 되던 Synology 배포 잡 조건을 deploy→main 으로 정정, 빌드한 APK 를 GitHub Release 에 첨부, Play Store AAB 업로드 경로가 FLUTTER_ROOT 를 가리키던 것을 workspace 로 수정",
+      "parsed_changes": {
+        "수정": {
+          "title": "🐛 수정",
+          "items": [
+            "릴리스 APK 첨부 및 배포 잔재 수정 — main push 에서 skip 되던 Synology 배포 잡 조건을 deploy→main 으로 정정, 빌드한 APK 를 GitHub Release 에 첨부, Play Store AAB 업로드 경로가 FLUTTER_ROOT 를 가리키던 것을 workspace 로 수정"
+          ]
+        }
+      },
+      "parse_method": "markdown"
+    },
     {
       "version": "1.2.40",
       "project_type": "flutter",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Changelog
 
-**현재 버전:** 1.2.40  
-**마지막 업데이트:** 2026-08-06T06:31:02Z  
+**현재 버전:** 1.2.41  
+**마지막 업데이트:** 2026-08-06T07:17:31Z  
+
+---
+
+## [1.2.41] - 2026-08-06
+
+**PR:** #78  
+
+**🐛 수정**
+- 릴리스 APK 첨부 및 배포 잔재 수정 — main push 에서 skip 되던 Synology 배포 잡 조건을 deploy→main 으로 정정, 빌드한 APK 를 GitHub Release 에 첨부, Play Store AAB 업로드 경로가 FLUTTER_ROOT 를 가리키던 것을 workspace 로 수정
 
 ---
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: ear_loc_alert
 description: "특정 위치에 도착·출발할 때 진동 또는 블루투스 이어폰으로만 알리는 위치 기반 알림 앱"
 publish_to: 'none'
 # 버전은 version.yml 이 단일 출처다. 직접 수정하지 않는다 (docs/08-OPERATIONS.md)
-version: 1.2.40+71
+version: 1.2.41+72
 # Dart 3.9+ (docs/02-ARCHITECTURE.md) — 와일드카드 파라미터 등 3.7+ 문법을 쓴다
 environment:
   sdk: '>=3.9.0 <4.0.0'

--- a/version.yml
+++ b/version.yml
@@ -24,8 +24,8 @@
 # - basic: version.yml only
 # ===
 
-version: "1.2.40"
-version_code: 72  # app build number
+version: "1.2.41"
+version_code: 73  # app build number
 # 마법사가 신규 통합으로 보고 1 로 초기화했는데, version_manager.py 가
 # pubspec 을 "version+version_code" 로 덮어쓰므로 그대로 두면 다음 배포에서
 # versionCode 가 71 → 2 로 떨어져 Play Store 가 업로드를 거부한다.


### PR DESCRIPTION
v1.2.40 배포 과정에서 드러난 배포 파이프라인 결함 세 건을 고칩니다.

## 1. Synology 배포 잡이 조용히 skip 되던 문제

`deploy` 브랜치를 걷어내고 트리거를 `main` 으로 옮겼는데, **잡 조건에 `refs/heads/deploy` 가 남아 있었습니다.**

```yaml
  deploy-android:
    needs: build-android
    if: github.ref == 'refs/heads/deploy'   # ← 트리거만 바꾸면 여기서 skip 된다
```

워크플로우는 초록으로 끝나고 APK 도 빌드되는데, 배포 잡만 조용히 건너뛰어서 **성공으로 보이지만 아무 데도 안 올라갑니다.** `main` 으로 정정했습니다.

## 2. GitHub Release 에 APK 가 없던 문제

`RELEASE-PUBLISH` 는 릴리스 노트만 만들고 산출물을 붙이지 않습니다. APK 는 워크플로우 아티팩트로만 남는데, **1일 뒤 사라지고 로그인해야 받을 수 있습니다.** 실기기에 설치할 파일이 릴리스에 있어야 합니다.

APK 빌드 직후 릴리스에 첨부하는 단계를 넣었습니다. 두 워크플로우가 main push 로 동시에 시작하므로 릴리스가 생길 때까지 기다렸다가 붙이고, 끝내 없으면 경고만 남기고 배포를 막지 않습니다.

## 3. Play Store AAB 업로드 경로 오류

AAB 는 52.5MB 로 정상 빌드되는데 업로드가 비어서 다음 잡이 죽었습니다.

```
빌드   : /home/runner/work/EarLocAlert/EarLocAlert/build/.../app-release.aab  ✅
업로드 : ${{ env.FLUTTER_ROOT }}/build/.../app-release.aab                   ❌ 없음
```

`FLUTTER_ROOT` 는 Flutter SDK 설치 경로(`/opt/hostedtoolcache/...`)지 작업 공간이 아닙니다. `github.workspace` 로 고쳤습니다.

이 셋 다 `project-auto-wizard` 통합분 또는 그 마이그레이션에서 나온 것이고, 마법사 쪽에도 이슈로 올립니다.

## 참고

Play Store 배포 자체는 아직 설정 전이라 이번에도 완주하지 않을 수 있습니다. 이 PR 의 목적은 **APK 가 릴리스에 남게 하는 것**입니다.
